### PR TITLE
filter task groups on target rather than getting indexes with target

### DIFF
--- a/R/load_model_out_in_window.R
+++ b/R/load_model_out_in_window.R
@@ -15,15 +15,11 @@ load_model_out_in_window <- function(hub_path, target_id, eval_window) {
   hub_tasks_config <- hubUtils::read_config(hub_path, config = "tasks")
   round_ids <- hubUtils::get_round_ids(hub_tasks_config)
   task_groups <- hubUtils::get_round_model_tasks(hub_tasks_config, round_ids[1])
-  target_ids_by_task_group <- get_target_ids_by_task_group(task_groups)
-  task_group_idxs_w_target <- get_task_group_idxs_w_target(target_id, target_ids_by_task_group)
+  task_groups_w_target <- filter_task_groups_to_target(task_groups, target_id)
 
-  target_meta <- purrr::keep(
-    task_groups[[task_group_idxs_w_target[[1]]]]$target_metadata,
-    function(x) x$target_id == target_id
-  )
-  target_task_id_var_name <- names(target_meta[[1]]$target_keys)
-  target_task_id_value <- target_meta[[1]]$target_keys[[target_task_id_var_name]]
+  target_meta <- task_groups_w_target[[1]]$target_metadata[[1]]
+  target_task_id_var_name <- names(target_meta$target_keys)
+  target_task_id_value <- target_meta$target_keys[[target_task_id_var_name]]
 
   conn <- conn |>
     dplyr::filter(!!rlang::sym(target_task_id_var_name) == target_task_id_value)

--- a/tests/testthat/test-utils-hub_tasks_config.R
+++ b/tests/testthat/test-utils-hub_tasks_config.R
@@ -1,14 +1,16 @@
 test_that(
-  "get_target_ids_by_task_group works",
+  "filter_task_groups_to_target works",
   {
     task_groups <- list(
       list(
+        group_number = 1,
         target_metadata = list(
           list(target_id = "target_id_1"),
           list(target_id = "target_id_2")
         )
       ),
       list(
+        group_number = 2,
         target_metadata = list(
           list(target_id = "target_id_3"),
           list(target_id = "target_id_4"),
@@ -16,59 +18,41 @@ test_that(
         )
       ),
       list(
+        group_number = 3,
         target_metadata = list(
           list(target_id = "target_id_4")
         )
       )
     )
 
-    target_ids_by_task_group <- get_target_ids_by_task_group(task_groups)
-
     expect_equal(
-      target_ids_by_task_group,
+      filter_task_groups_to_target(task_groups, "target_id_1"),
       list(
-        c("target_id_1", "target_id_2"),
-        c("target_id_3", "target_id_4", "target_id_5"),
-        "target_id_4"
-      )
-    )
-  }
-)
-
-test_that(
-  "get_task_group_idxs_w_target works",
-  {
-    task_groups <- list(
-      list(
-        target_metadata = list(
-          list(target_id = "target_id_1"),
-          list(target_id = "target_id_2")
-        )
-      ),
-      list(
-        target_metadata = list(
-          list(target_id = "target_id_3"),
-          list(target_id = "target_id_4"),
-          list(target_id = "target_id_5")
-        )
-      ),
-      list(
-        target_metadata = list(
-          list(target_id = "target_id_4")
+        list(
+          group_number = 1,
+          target_metadata = list(
+            list(target_id = "target_id_1")
+          )
         )
       )
     )
 
-    target_ids_by_task_group <- get_target_ids_by_task_group(task_groups)
-
     expect_equal(
-      get_task_group_idxs_w_target("target_id_1", target_ids_by_task_group),
-      1L
-    )
-
-    expect_equal(
-      get_task_group_idxs_w_target("target_id_4", target_ids_by_task_group),
-      c(2L, 3L)
+      filter_task_groups_to_target(task_groups, "target_id_4"),
+      list(
+        list(
+          group_number = 2,
+          target_metadata = list(
+            list(target_id = "target_id_4")
+          )
+        ),
+        list(
+          group_number = 3,
+          target_metadata = list(
+            list(target_id = "target_id_4")
+          )
+        )
+      )
     )
   }
 )

--- a/tests/testthat/test-utils-hub_tasks_config.R
+++ b/tests/testthat/test-utils-hub_tasks_config.R
@@ -54,5 +54,10 @@ test_that(
         )
       )
     )
+
+    expect_equal(
+      filter_task_groups_to_target(task_groups, "NOT A REAL TARGET ID"),
+      list()
+    )
   }
 )


### PR DESCRIPTION
This PR does a piece of refactoring that we identified as a nice-to-have in the review of #5.