### PR TITLE
Enable air formatting (closes #38)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -12,3 +12,5 @@
 ^_pkgdown\.yml$
 ^docs$
 ^pkgdown$
+^[.]?air[.]toml$
+^\.vscode$

--- a/.github/workflows/format-check.yaml
+++ b/.github/workflows/format-check.yaml
@@ -1,0 +1,23 @@
+# Workflow derived from https://github.com/posit-dev/setup-air/tree/main/examples
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+name: format-check.yaml
+
+permissions: read-all
+
+jobs:
+  format-check:
+    name: format-check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install
+        uses: posit-dev/setup-air@v1
+
+      - name: Check
+        run: air format . --check

--- a/.lintr
+++ b/.lintr
@@ -1,4 +1,5 @@
 linters: linters_with_defaults(
     line_length_linter = line_length_linter(120L),
+    indentation_linter = NULL,
     commented_code_linter = NULL
   )

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "Posit.air-vscode"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+    "[r]": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "Posit.air-vscode"
+    },
+    "[quarto]": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "quarto.quarto"
+    }
+}

--- a/R/config.R
+++ b/R/config.R
@@ -41,8 +41,11 @@ validate_config_vs_schema <- function(config) {
   config_json <- jsonlite::toJSON(config, auto_unbox = TRUE)
   schema_json <- load_schema_json(config)
 
-  valid <- jsonvalidate::json_validate(config_json, schema_json,
-    engine = "ajv", verbose = TRUE,
+  valid <- jsonvalidate::json_validate(
+    config_json,
+    schema_json,
+    engine = "ajv",
+    verbose = TRUE,
     greedy = TRUE
   )
 
@@ -52,8 +55,10 @@ validate_config_vs_schema <- function(config) {
         m = dplyr::case_when(
           .data$keyword == "required" ~ paste(.data$message, "."),
           .data$keyword == "additionalProperties" ~ paste0(
-            .data$message, "; saw unexpected property '",
-            .data$params$additionalProperty, "'."
+            .data$message,
+            "; saw unexpected property '",
+            .data$params$additionalProperty,
+            "'."
           ),
           TRUE ~ paste("-", .data$instancePath, .data$message, ".")
         )
@@ -76,12 +81,18 @@ validate_config_vs_schema <- function(config) {
 #'
 #' @noRd
 load_schema_json <- function(config) {
-  if (! "schema_version" %in% names(config)) {
-    raise_config_error("The predevals config file is required to contain a `schema_version` property.")
+  if (!"schema_version" %in% names(config)) {
+    raise_config_error(
+      "The predevals config file is required to contain a `schema_version` property."
+    )
   }
 
-  if (! is.character(config$schema_version) || length(config$schema_version) != 1) {
-    raise_config_error("The `schema_version` property of the config schema must be a string.")
+  if (
+    !is.character(config$schema_version) || length(config$schema_version) != 1
+  ) {
+    raise_config_error(
+      "The `schema_version` property of the config schema must be a string."
+    )
   }
 
   schema_version <- hubUtils::extract_schema_version(config$schema_version)
@@ -99,7 +110,7 @@ load_schema_json <- function(config) {
     full.names = FALSE,
     recursive = FALSE
   )
-  if (! schema_version %in% available_versions) {
+  if (!schema_version %in% available_versions) {
     raise_config_error(
       c(
         cli::format_inline(
@@ -132,12 +143,14 @@ load_schema_json <- function(config) {
     )
   }
 
-  schema_path <- system.file("schema", schema_version, "config_schema.json",
-                             package = "hubPredEvalsData")
+  schema_path <- system.file(
+    "schema",
+    schema_version,
+    "config_schema.json",
+    package = "hubPredEvalsData"
+  )
 
-  schema_json <- jsonlite::read_json(schema_path,
-    auto_unbox = TRUE
-  ) |>
+  schema_json <- jsonlite::read_json(schema_path, auto_unbox = TRUE) |>
     jsonlite::toJSON(auto_unbox = TRUE)
 
   schema_json
@@ -161,7 +174,7 @@ validate_config_vs_hub_tasks <- function(hub_path, predevals_config) {
     )
   }
 
-  rounds_idx <- predevals_config$rounds_idx + 1  # Convert 0-based rounds_idx to 1-based for R indexing
+  rounds_idx <- predevals_config$rounds_idx + 1 # Convert 0-based rounds_idx to 1-based for R indexing
   if (!hub_tasks_config[["rounds"]][[rounds_idx]][["round_id_from_variable"]]) {
     raise_config_error(
       "hubPredEvalsData only supports hubs with `round_id_from_variable` set to `true` in `tasks.json`."
@@ -174,7 +187,12 @@ validate_config_vs_hub_tasks <- function(hub_path, predevals_config) {
   validate_config_targets(predevals_config, task_groups, task_id_names)
 
   # checks for eval_sets
-  validate_config_eval_sets(predevals_config, hub_tasks_config, task_groups, task_id_names)
+  validate_config_eval_sets(
+    predevals_config,
+    hub_tasks_config,
+    task_groups,
+    task_id_names
+  )
 
   # checks for task_id_text
   validate_config_task_id_text(predevals_config, task_groups, task_id_names)
@@ -187,7 +205,11 @@ validate_config_vs_hub_tasks <- function(hub_path, predevals_config) {
 #' - disaggregate_by entries are task id variable names
 #'
 #' @noRd
-validate_config_targets <- function(predevals_config, task_groups, task_id_names) {
+validate_config_targets <- function(
+  predevals_config,
+  task_groups,
+  task_id_names
+) {
   for (target in predevals_config$targets) {
     target_id <- target$target_id
 
@@ -197,7 +219,9 @@ validate_config_targets <- function(predevals_config, task_groups, task_id_names
     # check that target_id in the predevals config appears in the hub tasks
     if (length(task_groups_w_target) == 0) {
       raise_config_error(
-        cli::format_inline("Target id {.val {target_id}} not found in any task group.")
+        cli::format_inline(
+          "Target id {.val {target_id}} not found in any task group."
+        )
       )
     }
 
@@ -208,7 +232,9 @@ validate_config_targets <- function(predevals_config, task_groups, task_id_names
     )
     unsupported_metrics <- setdiff(
       target$metrics,
-      metric_name_to_output_type$metric[!is.na(metric_name_to_output_type$output_type)]
+      metric_name_to_output_type$metric[
+        !is.na(metric_name_to_output_type$output_type)
+      ]
     )
 
     if (length(unsupported_metrics) > 0) {
@@ -243,7 +269,9 @@ validate_config_targets <- function(predevals_config, task_groups, task_id_names
             "Requested relative metrics for metrics that were not requested ",
             "for {.arg target_id} {.val {target_id}}."
           ),
-          "i" = cli::format_inline("Requested metric{?s}: {.val {target$metrics}}."),
+          "i" = cli::format_inline(
+            "Requested metric{?s}: {.val {target$metrics}}."
+          ),
           "x" = cli::format_inline(
             "Relative metric{?s} not found in the requested metrics: ",
             "{.val {extra_relative_metrics}}."
@@ -277,13 +305,20 @@ validate_config_targets <- function(predevals_config, task_groups, task_id_names
 #'    for that task id as specified in the hub's config
 #'
 #' @noRd
-validate_config_eval_sets <- function(predevals_config, hub_tasks_config, task_groups, task_id_names) {
+validate_config_eval_sets <- function(
+  predevals_config,
+  hub_tasks_config,
+  task_groups,
+  task_id_names
+) {
   hub_round_ids <- hubUtils::get_round_ids(hub_tasks_config)
   for (eval_set in predevals_config$eval_sets) {
     # check that min is a valid round_id
     # only do this check if eval_set$round_filters$min is specified
     round_filters <- eval_set$round_filters
-    if ("min" %in% names(round_filters) && !round_filters$min %in% hub_round_ids) {
+    if (
+      "min" %in% names(round_filters) && !round_filters$min %in% hub_round_ids
+    ) {
       raise_config_error(
         cli::format_inline(
           "Minimum round id {.val {round_filters$min}} for evaluation ",
@@ -313,7 +348,10 @@ validate_config_eval_sets <- function(predevals_config, hub_tasks_config, task_g
     error_messages <- purrr::map(
       task_ids_filtered_on,
       function(task_id_name) {
-        extra_set_filter_values <- setdiff(task_filters[[task_id_name]], get_task_id_values(task_groups, task_id_name))
+        extra_set_filter_values <- setdiff(
+          task_filters[[task_id_name]],
+          get_task_id_values(task_groups, task_id_name)
+        )
         if (length(extra_set_filter_values) == 0) {
           NULL
         } else {
@@ -338,7 +376,11 @@ validate_config_eval_sets <- function(predevals_config, hub_tasks_config, task_g
 #' - check that all values of the task id variable in the hub appear as task_id_text item keys
 #'
 #' @noRd
-validate_config_task_id_text <- function(predevals_config, task_groups, task_id_names) {
+validate_config_task_id_text <- function(
+  predevals_config,
+  task_groups,
+  task_id_names
+) {
   # all task_id_text items must be valid task id variable names
   extra_task_id_text_names <- setdiff(
     names(predevals_config$task_id_text),

--- a/R/generate_eval_data.R
+++ b/R/generate_eval_data.R
@@ -7,10 +7,7 @@
 #' @param oracle_output A data frame of oracle output to use for the evaluation.
 #'
 #' @export
-generate_eval_data <- function(hub_path,
-                               config_path,
-                               out_path,
-                               oracle_output) {
+generate_eval_data <- function(hub_path, config_path, out_path, oracle_output) {
   config <- read_predevals_config(hub_path, config_path)
   for (target in config$targets) {
     generate_target_eval_data(hub_path, config, out_path, oracle_output, target)
@@ -27,11 +24,13 @@ generate_eval_data <- function(hub_path,
 #' "metrics", and "disaggregate_by".
 #'
 #' @noRd
-generate_target_eval_data <- function(hub_path,
-                                      config,
-                                      out_path,
-                                      oracle_output,
-                                      target) {
+generate_target_eval_data <- function(
+  hub_path,
+  config,
+  out_path,
+  oracle_output,
+  target
+) {
   target_id <- target$target_id
   metrics <- target$metrics
   # if relative_metrics and baseline are not provided, the are NULL
@@ -41,11 +40,23 @@ generate_target_eval_data <- function(hub_path,
   disaggregate_by <- c(list(NULL), as.list(target$disaggregate_by))
   eval_sets <- config$eval_sets
 
-  task_groups_w_target <- get_task_groups_w_target(hub_path, target_id, config$rounds_idx)
-  metric_name_to_output_type <- get_metric_name_to_output_type(task_groups_w_target, metrics)
+  task_groups_w_target <- get_task_groups_w_target(
+    hub_path,
+    target_id,
+    config$rounds_idx
+  )
+  metric_name_to_output_type <- get_metric_name_to_output_type(
+    task_groups_w_target,
+    metrics
+  )
 
   for (eval_set in eval_sets) {
-    model_out_tbl <- load_model_out_in_eval_set(hub_path, target$target_id, eval_set, config$rounds_idx)
+    model_out_tbl <- load_model_out_in_eval_set(
+      hub_path,
+      target$target_id,
+      eval_set,
+      config$rounds_idx
+    )
     if (nrow(model_out_tbl) == 0) {
       cli::cli_inform(
         "No model output data found for target {.val {target_id}}
@@ -81,10 +92,17 @@ generate_target_eval_data <- function(hub_path,
 #' - If by is not NULL, the scores are saved in
 #' out_path/target_id/eval_set_name/by/scores.csv
 #' @noRd
-get_and_save_scores <- function(model_out_tbl, oracle_output, metric_name_to_output_type,
-                                relative_metrics, baseline,
-                                target_id, eval_set_name, by,
-                                out_path) {
+get_and_save_scores <- function(
+  model_out_tbl,
+  oracle_output,
+  metric_name_to_output_type,
+  relative_metrics,
+  baseline,
+  target_id,
+  eval_set_name,
+  by,
+  out_path
+) {
   # Iterate over the output types and calculate scores for each
   scores <- purrr::map(
     unique(metric_name_to_output_type$output_type),
@@ -108,7 +126,9 @@ get_and_save_scores <- function(model_out_tbl, oracle_output, metric_name_to_out
   # rows within each group.
   group_cols <- c("model_id", by)
   n_tasks_by_group <- model_out_tbl |>
-    dplyr::select(!dplyr::all_of(c("output_type", "output_type_id", "value"))) |>
+    dplyr::select(
+      !dplyr::all_of(c("output_type", "output_type_id", "value"))
+    ) |>
     dplyr::group_by(dplyr::across(dplyr::all_of(group_cols))) |>
     dplyr::distinct() |>
     dplyr::summarize(n = dplyr::n())
@@ -122,18 +142,27 @@ get_and_save_scores <- function(model_out_tbl, oracle_output, metric_name_to_out
   if (!dir.exists(target_set_by_out_path)) {
     dir.create(target_set_by_out_path, recursive = TRUE)
   }
-  utils::write.csv(scores,
-                   file = file.path(target_set_by_out_path, "scores.csv"),
-                   row.names = FALSE)
+  utils::write.csv(
+    scores,
+    file = file.path(target_set_by_out_path, "scores.csv"),
+    row.names = FALSE
+  )
 }
 
 
 #' Get scores for a target in a given evaluation set for a specific output type.
 #' @noRd
-get_scores_for_output_type <- function(model_out_tbl, oracle_output, metric_name_to_output_type,
-                                       relative_metrics, baseline,
-                                       target_id, eval_set_name, by,
-                                       output_type) {
+get_scores_for_output_type <- function(
+  model_out_tbl,
+  oracle_output,
+  metric_name_to_output_type,
+  relative_metrics,
+  baseline,
+  target_id,
+  eval_set_name,
+  by,
+  output_type
+) {
   metrics <- metric_name_to_output_type$metric[
     metric_name_to_output_type$output_type == output_type
   ]
@@ -141,7 +170,8 @@ get_scores_for_output_type <- function(model_out_tbl, oracle_output, metric_name
     relative_metrics <- relative_metrics[relative_metrics %in% metrics]
   }
   scores <- hubEvals::score_model_out(
-    model_out_tbl = model_out_tbl |> dplyr::filter(.data[["output_type"]] == !!output_type),
+    model_out_tbl = model_out_tbl |>
+      dplyr::filter(.data[["output_type"]] == !!output_type),
     oracle_output = oracle_output,
     metrics = metrics,
     relative_metrics = relative_metrics,
@@ -160,7 +190,11 @@ get_scores_for_output_type <- function(model_out_tbl, oracle_output, metric_name
       metrics,
       function(metric) {
         c(
-          if (metric %in% relative_metrics) paste0(metric, "_scaled_relative_skill") else NULL,
+          if (metric %in% relative_metrics) {
+            paste0(metric, "_scaled_relative_skill")
+          } else {
+            NULL
+          },
           metric
         )
       }

--- a/R/load_model_out_in_eval_set.R
+++ b/R/load_model_out_in_eval_set.R
@@ -9,7 +9,12 @@
 #'
 #' @return A data frame containing the model output data.
 #' @noRd
-load_model_out_in_eval_set <- function(hub_path, target_id, eval_set, rounds_idx) {
+load_model_out_in_eval_set <- function(
+  hub_path,
+  target_id,
+  eval_set,
+  rounds_idx
+) {
   conn <- hubData::connect_hub(hub_path)
 
   # filter to the requested target_id
@@ -44,7 +49,9 @@ load_model_out_in_eval_set <- function(hub_path, target_id, eval_set, rounds_idx
   round_filters <- eval_set$round_filters
 
   # if eval_set specifies a minimum round id, filter to that
-  round_id_var_name <- hub_tasks_config[["rounds"]][[rounds_idx + 1]][["round_id"]]
+  round_id_var_name <- hub_tasks_config[["rounds"]][[rounds_idx + 1]][[
+    "round_id"
+  ]]
   if ("min" %in% names(round_filters)) {
     conn <- conn |>
       dplyr::filter(!!rlang::sym(round_id_var_name) >= round_filters$min)

--- a/R/utils-hub_tasks_config.R
+++ b/R/utils-hub_tasks_config.R
@@ -38,8 +38,10 @@ filter_task_groups_to_target <- function(task_groups, target_id) {
   task_groups <- purrr::map(
     task_groups,
     function(task_group) {
-      task_group$target_metadata <- purrr::keep(task_group$target_metadata,
-                                                ~ .x$target_id == target_id)
+      task_group$target_metadata <- purrr::keep(
+        task_group$target_metadata,
+        ~ .x$target_id == target_id
+      )
       task_group
     }
   )
@@ -108,7 +110,9 @@ get_output_type_ids_for_type <- function(task_groups, output_type) {
   )
 
   # Small groups should contain subsets of the largest group, so this is our reference.
-  output_type_ids <- output_type_ids_by_group[[which.max(lengths(output_type_ids_by_group))]]
+  output_type_ids <- output_type_ids_by_group[[which.max(lengths(
+    output_type_ids_by_group
+  ))]]
 
   # check that the output type id values in each group are a (possibly improper)
   # subset of the output type id values in the group with the most values, in
@@ -127,7 +131,9 @@ get_output_type_ids_for_type <- function(task_groups, output_type) {
 
     # if output_type_ids and output_type_ids_group have some entries in common
     # but order differs, raise an error
-    output_type_ids_subset <- output_type_ids[output_type_ids %in% output_type_ids_group]
+    output_type_ids_subset <- output_type_ids[
+      output_type_ids %in% output_type_ids_group
+    ]
     if (!identical(output_type_ids_subset, output_type_ids_group)) {
       cli::cli_abort(
         "In hub's tasks.json, output type ids for output type {.val {output_type}}

--- a/R/utils-metrics.R
+++ b/R/utils-metrics.R
@@ -25,7 +25,10 @@ get_metric_name_to_output_type <- function(task_groups_w_target, metrics) {
 
   # manually handle interval coverage
   if ("quantile" %in% available_output_types) {
-    result$output_type[grepl(pattern = "^interval_coverage_", x = metrics)] <- "quantile"
+    result$output_type[grepl(
+      pattern = "^interval_coverage_",
+      x = metrics
+    )] <- "quantile"
   }
 
   # other metrics

--- a/tests/testthat/helper-check_exp_scores_for_set.R
+++ b/tests/testthat/helper-check_exp_scores_for_set.R
@@ -59,10 +59,11 @@ check_exp_scores_for_set <- function(
         dplyr::select(-dplyr::contains("relative"))
     }
 
+    # nolint next: object_usage_linter.
     expect_df_equal_up_to_order(
       actual_scores,
       expected_scores,
       ignore_attr = TRUE
-    ) # nolint: object_usage_linter
+    )
   }
 }

--- a/tests/testthat/helper-check_exp_scores_for_set.R
+++ b/tests/testthat/helper-check_exp_scores_for_set.R
@@ -5,24 +5,52 @@
 #' @param model_out_tbl The model output table, filtered to data for the evaluation window.
 #' @param oracle_output The oracle output.
 #' @param include_rel Whether to include relative metrics in the expected scores.
-check_exp_scores_for_set <- function(out_path, set_name, model_out_tbl, oracle_output,
-                                     include_rel = FALSE) {
+check_exp_scores_for_set <- function(
+  out_path,
+  set_name,
+  model_out_tbl,
+  oracle_output,
+  include_rel = FALSE
+) {
   # check that the output files were created and have the expected contents
   # disaggregated by `by` if non-NULL, otherwise no disaggregation
-  for (by in list(NULL, "location", "reference_date", "horizon", "target_end_date")) {
+  for (by in list(
+    NULL,
+    "location",
+    "reference_date",
+    "horizon",
+    "target_end_date"
+  )) {
     if (is.null(by)) {
-      scores_path <- file.path(out_path, "wk inc flu hosp", set_name, "scores.csv")
+      scores_path <- file.path(
+        out_path,
+        "wk inc flu hosp",
+        set_name,
+        "scores.csv"
+      )
     } else {
-      scores_path <- file.path(out_path, "wk inc flu hosp", set_name, by, "scores.csv")
+      scores_path <- file.path(
+        out_path,
+        "wk inc flu hosp",
+        set_name,
+        by,
+        "scores.csv"
+      )
     }
     testthat::expect_true(file.exists(scores_path))
 
     actual_scores <- read.csv(scores_path)
 
-    file_name <- paste0("scores_", set_name, ifelse(is.null(by), "", paste0("_by_", by)), ".csv")
+    file_name <- paste0(
+      "scores_",
+      set_name,
+      ifelse(is.null(by), "", paste0("_by_", by)),
+      ".csv"
+    )
     file_name <- gsub(" ", "_", file_name)
     expected_scores_path <- testthat::test_path(
-      "testdata", "expected-scores",
+      "testdata",
+      "expected-scores",
       file_name
     )
     expected_scores <- read.csv(expected_scores_path)
@@ -31,6 +59,10 @@ check_exp_scores_for_set <- function(out_path, set_name, model_out_tbl, oracle_o
         dplyr::select(-dplyr::contains("relative"))
     }
 
-    expect_df_equal_up_to_order(actual_scores, expected_scores, ignore_attr = TRUE) # nolint: object_usage_linter
+    expect_df_equal_up_to_order(
+      actual_scores,
+      expected_scores,
+      ignore_attr = TRUE
+    ) # nolint: object_usage_linter
   }
 }

--- a/tests/testthat/helper-expect_df_equal_up_to_order.R
+++ b/tests/testthat/helper-expect_df_equal_up_to_order.R
@@ -2,7 +2,12 @@
 #'
 #' @param df_act The actual data frame
 #' @param df_exp The expected data frame
-expect_df_equal_up_to_order <- function(df_act, df_exp, ignore_attr = FALSE, ...) {
+expect_df_equal_up_to_order <- function(
+  df_act,
+  df_exp,
+  ignore_attr = FALSE,
+  ...
+) {
   cols <- colnames(df_act)
   testthat::expect_equal(cols, colnames(df_exp))
   testthat::expect_equal(

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -142,6 +142,7 @@ test_that("read_predevals_config fails, arbitrary string schema_version in yaml 
   )
 })
 
+# nolint next: line_length_linter.
 test_that("read_predevals_config fails, well-formatted but unsupported schema_version in yaml file (version never existed)", {
   hub_path <- test_path("testdata", "ecfh")
   expect_error(

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -1,410 +1,370 @@
-test_that(
-  "read_predevals_config succeeds, valid yaml file",
-  {
-    hub_path <- test_path("testdata", "ecfh")
-    expect_snapshot(
-      read_predevals_config(
-        hub_path,
-        test_path("testdata", "test_configs",
-                  "config_valid.yaml")
+test_that("read_predevals_config succeeds, valid yaml file", {
+  hub_path <- test_path("testdata", "ecfh")
+  expect_snapshot(
+    read_predevals_config(
+      hub_path,
+      test_path("testdata", "test_configs", "config_valid.yaml")
+    )
+  )
+})
+
+test_that("read_predevals_config succeeds, valid yaml file two rounds", {
+  hub_path <- test_path("testdata", "ecfh")
+  expect_snapshot(
+    read_predevals_config(
+      hub_path,
+      test_path("testdata", "test_configs", "config_valid_two_rounds.yaml")
+    )
+  )
+})
+
+test_that("read_predevals_config succeeds, valid yaml file with task id filters", {
+  hub_path <- test_path("testdata", "ecfh")
+  expect_snapshot(
+    read_predevals_config(
+      hub_path,
+      test_path("testdata", "test_configs", "config_valid_set_filters.yaml")
+    )
+  )
+})
+
+test_that("read_predevals_config succeeds, valid yaml file with length 1 arrays", {
+  hub_path <- test_path("testdata", "ecfh")
+  expect_snapshot(
+    read_predevals_config(
+      hub_path,
+      test_path(
+        "testdata",
+        "test_configs",
+        "config_valid_length_one_arrays.yaml"
       )
     )
-  }
-)
+  )
+})
 
-test_that(
-  "read_predevals_config succeeds, valid yaml file two rounds",
-  {
-    hub_path <- test_path("testdata", "ecfh")
-    expect_snapshot(
-      read_predevals_config(
-        hub_path,
-        test_path("testdata", "test_configs",
-                  "config_valid_two_rounds.yaml")
+test_that("read_predevals_config succeeds, valid yaml file with relative metrics", {
+  hub_path <- test_path("testdata", "ecfh")
+  expect_snapshot(
+    read_predevals_config(
+      hub_path,
+      test_path("testdata", "test_configs", "config_valid_rel_metrics.yaml")
+    )
+  )
+})
+
+test_that("read_predevals_config succeeds, valid yaml file with no min_round_id", {
+  hub_path <- test_path("testdata", "ecfh")
+  expect_snapshot(
+    read_predevals_config(
+      hub_path,
+      test_path("testdata", "test_configs", "config_valid_no_min_round_id.yaml")
+    )
+  )
+})
+
+test_that("read_predevals_config succeeds, valid yaml file with no disaggregate_by", {
+  hub_path <- test_path("testdata", "ecfh")
+  expect_snapshot(
+    read_predevals_config(
+      hub_path,
+      test_path(
+        "testdata",
+        "test_configs",
+        "config_valid_no_disaggregate_by.yaml"
       )
     )
-  }
-)
+  )
+})
 
-test_that(
-  "read_predevals_config succeeds, valid yaml file with task id filters",
-  {
-    hub_path <- test_path("testdata", "ecfh")
-    expect_snapshot(
-      read_predevals_config(
-        hub_path,
-        test_path("testdata", "test_configs",
-                  "config_valid_set_filters.yaml")
+test_that("read_predevals_config succeeds, valid yaml file with no task_id_text", {
+  hub_path <- test_path("testdata", "ecfh")
+  expect_snapshot(
+    read_predevals_config(
+      hub_path,
+      test_path("testdata", "test_configs", "config_valid_no_task_id_text.yaml")
+    )
+  )
+})
+
+test_that("read_predevals_config fails, invalid yaml file", {
+  hub_path <- test_path("testdata", "ecfh")
+  expect_error(
+    read_predevals_config(
+      hub_path,
+      test_path("testdata", "test_configs", "config_invalid_yaml.yaml")
+    ),
+    regexp = "Error reading predevals config file"
+  )
+})
+
+test_that("read_predevals_config fails, no schema_version in yaml file", {
+  hub_path <- test_path("testdata", "ecfh")
+  expect_error(
+    read_predevals_config(
+      hub_path,
+      test_path(
+        "testdata",
+        "test_configs",
+        "config_invalid_no_schema_version.yaml"
       )
-    )
-  }
-)
+    ),
+    regexp = "The predevals config file is required to contain a `schema_version` property."
+  )
+})
 
-test_that(
-  "read_predevals_config succeeds, valid yaml file with length 1 arrays",
-  {
-    hub_path <- test_path("testdata", "ecfh")
-    expect_snapshot(
-      read_predevals_config(
-        hub_path,
-        test_path("testdata", "test_configs",
-                  "config_valid_length_one_arrays.yaml")
+test_that("read_predevals_config fails, schema_version is array in yaml file", {
+  hub_path <- test_path("testdata", "ecfh")
+  expect_error(
+    read_predevals_config(
+      hub_path,
+      test_path(
+        "testdata",
+        "test_configs",
+        "config_invalid_array_schema_version.yaml"
       )
-    )
-  }
-)
+    ),
+    regexp = "The `schema_version` property of the config schema must be a string."
+  )
+})
 
-test_that(
-  "read_predevals_config succeeds, valid yaml file with relative metrics",
-  {
-    hub_path <- test_path("testdata", "ecfh")
-    expect_snapshot(
-      read_predevals_config(
-        hub_path,
-        test_path("testdata", "test_configs",
-                  "config_valid_rel_metrics.yaml")
+test_that("read_predevals_config fails, arbitrary string schema_version in yaml file", {
+  hub_path <- test_path("testdata", "ecfh")
+  expect_error(
+    read_predevals_config(
+      hub_path,
+      test_path(
+        "testdata",
+        "test_configs",
+        "config_invalid_malformed_schema_version.yaml"
       )
-    )
-  }
-)
+    ),
+    regexp = "Invalid `schema_version` property of the config schema."
+  )
+})
 
-test_that(
-  "read_predevals_config succeeds, valid yaml file with no min_round_id",
-  {
-    hub_path <- test_path("testdata", "ecfh")
-    expect_snapshot(
-      read_predevals_config(
-        hub_path,
-        test_path("testdata", "test_configs",
-                  "config_valid_no_min_round_id.yaml")
+test_that("read_predevals_config fails, well-formatted but unsupported schema_version in yaml file (version never existed)", {
+  hub_path <- test_path("testdata", "ecfh")
+  expect_error(
+    read_predevals_config(
+      hub_path,
+      test_path(
+        "testdata",
+        "test_configs",
+        "config_invalid_nonexist_schema_version.yaml"
       )
-    )
-  }
-)
+    ),
+    regexp = "Invalid predevals schema version."
+  )
+})
 
-test_that(
-  "read_predevals_config succeeds, valid yaml file with no disaggregate_by",
-  {
-    hub_path <- test_path("testdata", "ecfh")
-    expect_snapshot(
-      read_predevals_config(
-        hub_path,
-        test_path("testdata", "test_configs",
-                  "config_valid_no_disaggregate_by.yaml")
+test_that("read_predevals_config fails, well-formatted but unsupported schema_version in yaml file (old version)", {
+  hub_path <- test_path("testdata", "ecfh")
+  expect_error(
+    read_predevals_config(
+      hub_path,
+      test_path(
+        "testdata",
+        "test_configs",
+        "config_invalid_old_schema_version.yaml"
       )
-    )
-  }
-)
+    ),
+    regexp = "The predevals schema version is too old. Please update to the latest schema version."
+  )
+})
 
-test_that(
-  "read_predevals_config succeeds, valid yaml file with no task_id_text",
-  {
-    hub_path <- test_path("testdata", "ecfh")
-    expect_snapshot(
-      read_predevals_config(
-        hub_path,
-        test_path("testdata", "test_configs",
-                  "config_valid_no_task_id_text.yaml")
+test_that("read_predevals_config succeeds, multiple modeling round groups with valid rounds_idx", {
+  hub_path <- test_path("testdata", "test_hub_invalid_mult_rnd")
+  expect_snapshot(
+    read_predevals_config(
+      hub_path,
+      test_path("testdata", "test_configs", "config_valid_rounds_idx_1.yaml")
+    )
+  )
+})
+
+test_that("read_predevals_config fails, rounds_idx out of bounds", {
+  hub_path <- test_path("testdata", "ecfh")
+  expect_error(
+    read_predevals_config(
+      hub_path,
+      test_path(
+        "testdata",
+        "test_configs",
+        "config_invalid_rounds_idx_out_of_bounds.yaml"
       )
-    )
-  }
-)
+    ),
+    regexp = "Invalid `rounds_idx` value 99. Must be less than the number of rounds"
+  )
+})
 
-test_that(
-  "read_predevals_config fails, invalid yaml file",
-  {
-    hub_path <- test_path("testdata", "ecfh")
-    expect_error(
-      read_predevals_config(
-        hub_path,
-        test_path("testdata", "test_configs",
-                  "config_invalid_yaml.yaml")
-      ),
-      regexp = "Error reading predevals config file"
-    )
-  }
-)
+test_that("read_predevals_config fails, round_id_from_variable false", {
+  hub_path <- test_path("testdata", "test_hub_invalid_rifv_F")
+  expect_error(
+    read_predevals_config(
+      hub_path,
+      test_path("testdata", "test_configs", "config_valid.yaml")
+    ),
+    regexp = "hubPredEvalsData only supports hubs with `round_id_from_variable` set to `true` in `tasks.json`."
+  )
+})
 
-test_that(
-  "read_predevals_config fails, no schema_version in yaml file",
-  {
-    hub_path <- test_path("testdata", "ecfh")
-    expect_error(
-      read_predevals_config(
-        hub_path,
-        test_path("testdata", "test_configs",
-                  "config_invalid_no_schema_version.yaml")
-      ),
-      regexp = "The predevals config file is required to contain a `schema_version` property."
-    )
-  }
-)
-
-test_that(
-  "read_predevals_config fails, schema_version is array in yaml file",
-  {
-    hub_path <- test_path("testdata", "ecfh")
-    expect_error(
-      read_predevals_config(
-        hub_path,
-        test_path("testdata", "test_configs",
-                  "config_invalid_array_schema_version.yaml")
-      ),
-      regexp = "The `schema_version` property of the config schema must be a string."
-    )
-  }
-)
-
-test_that(
-  "read_predevals_config fails, arbitrary string schema_version in yaml file",
-  {
-    hub_path <- test_path("testdata", "ecfh")
-    expect_error(
-      read_predevals_config(
-        hub_path,
-        test_path("testdata", "test_configs",
-                  "config_invalid_malformed_schema_version.yaml")
-      ),
-      regexp = "Invalid `schema_version` property of the config schema."
-    )
-  }
-)
-
-test_that(
-  "read_predevals_config fails, well-formatted but unsupported schema_version in yaml file (version never existed)",
-  {
-    hub_path <- test_path("testdata", "ecfh")
-    expect_error(
-      read_predevals_config(
-        hub_path,
-        test_path("testdata", "test_configs",
-                  "config_invalid_nonexist_schema_version.yaml")
-      ),
-      regexp = "Invalid predevals schema version."
-    )
-  }
-)
-
-test_that(
-  "read_predevals_config fails, well-formatted but unsupported schema_version in yaml file (old version)",
-  {
-    hub_path <- test_path("testdata", "ecfh")
-    expect_error(
-      read_predevals_config(
-        hub_path,
-        test_path("testdata", "test_configs",
-                  "config_invalid_old_schema_version.yaml")
-      ),
-      regexp = "The predevals schema version is too old. Please update to the latest schema version."
-    )
-  }
-)
-
-test_that(
-  "read_predevals_config succeeds, multiple modeling round groups with valid rounds_idx",
-  {
-    hub_path <- test_path("testdata", "test_hub_invalid_mult_rnd")
-    expect_snapshot(
-      read_predevals_config(
-        hub_path,
-        test_path("testdata", "test_configs",
-                  "config_valid_rounds_idx_1.yaml")
+test_that("read_predevals_config fails, invalid target id", {
+  hub_path <- test_path("testdata", "ecfh")
+  expect_error(
+    read_predevals_config(
+      hub_path,
+      test_path(
+        "testdata",
+        "test_configs",
+        "config_invalid_targets_target_id.yaml"
       )
-    )
-  }
-)
+    ),
+    regexp = 'Target id "THIS IS NOT A REAL TARGET ID" not found in any task group.'
+  )
+})
 
-test_that(
-  "read_predevals_config fails, rounds_idx out of bounds",
-  {
-    hub_path <- test_path("testdata", "ecfh")
-    expect_error(
-      read_predevals_config(
-        hub_path,
-        test_path("testdata", "test_configs",
-                  "config_invalid_rounds_idx_out_of_bounds.yaml")
-      ),
-      regexp = "Invalid `rounds_idx` value 99. Must be less than the number of rounds"
-    )
-  }
-)
+test_that("read_predevals_config fails, invalid metrics", {
+  hub_path <- test_path("testdata", "ecfh")
+  expect_error(
+    read_predevals_config(
+      hub_path,
+      test_path(
+        "testdata",
+        "test_configs",
+        "config_invalid_targets_metrics.yaml"
+      )
+    ),
+    regexp = 'Unsupported metrics: "THIS IS NOT A SUPPORTED METRIC" and "coverage_95".'
+  )
+})
 
-test_that(
-  "read_predevals_config fails, round_id_from_variable false",
-  {
-    hub_path <- test_path("testdata", "test_hub_invalid_rifv_F")
-    expect_error(
-      read_predevals_config(
-        hub_path,
-        test_path("testdata", "test_configs",
-                  "config_valid.yaml")
-      ),
-      regexp = "hubPredEvalsData only supports hubs with `round_id_from_variable` set to `true` in `tasks.json`."
-    )
-  }
-)
+test_that("read_predevals_config fails, invalid disaggregate by", {
+  hub_path <- test_path("testdata", "ecfh")
+  expect_error(
+    read_predevals_config(
+      hub_path,
+      test_path(
+        "testdata",
+        "test_configs",
+        "config_invalid_targets_disaggregate_by.yaml"
+      )
+    ),
+    regexp = 'Disaggregate by variables "THIS IS NOT A TASK ID VARIABLE" and "NEITHER IS THIS"'
+  )
+})
 
-test_that(
-  "read_predevals_config fails, invalid target id",
-  {
-    hub_path <- test_path("testdata", "ecfh")
-    expect_error(
-      read_predevals_config(
-        hub_path,
-        test_path("testdata", "test_configs",
-                  "config_invalid_targets_target_id.yaml")
-      ),
-      regexp = 'Target id "THIS IS NOT A REAL TARGET ID" not found in any task group.'
-    )
-  }
-)
+test_that("read_predevals_config fails, invalid eval set n_last", {
+  hub_path <- test_path("testdata", "ecfh")
+  expect_error(
+    read_predevals_config(
+      hub_path,
+      test_path("testdata", "test_configs", "config_invalid_set_n_last.yaml")
+    ),
+    regexp = "/eval_sets/1/round_filters/n_last must be >= 1"
+  )
+})
 
-test_that(
-  "read_predevals_config fails, invalid metrics",
-  {
-    hub_path <- test_path("testdata", "ecfh")
-    expect_error(
-      read_predevals_config(
-        hub_path,
-        test_path("testdata", "test_configs",
-                  "config_invalid_targets_metrics.yaml")
-      ),
-      regexp = 'Unsupported metrics: "THIS IS NOT A SUPPORTED METRIC" and "coverage_95".'
-    )
-  }
-)
+test_that("read_predevals_config fails, invalid eval set min_round_id", {
+  hub_path <- test_path("testdata", "ecfh")
+  expect_error(
+    read_predevals_config(
+      hub_path,
+      test_path(
+        "testdata",
+        "test_configs",
+        "config_invalid_set_min_round_id.yaml"
+      )
+    ),
+    regexp = 'Minimum round id "THIS IS NOT A ROUND ID" for evaluation set is not a valid round id for the hub.'
+  )
+})
 
-test_that(
-  "read_predevals_config fails, invalid disaggregate by",
-  {
-    hub_path <- test_path("testdata", "ecfh")
-    expect_error(
-      read_predevals_config(
-        hub_path,
-        test_path("testdata", "test_configs",
-                  "config_invalid_targets_disaggregate_by.yaml")
-      ),
-      regexp = 'Disaggregate by variables "THIS IS NOT A TASK ID VARIABLE" and "NEITHER IS THIS"'
-    )
-  }
-)
+test_that("read_predevals_config fails, invalid eval set task filter variable name", {
+  hub_path <- test_path("testdata", "ecfh")
+  expect_error(
+    read_predevals_config(
+      hub_path,
+      test_path(
+        "testdata",
+        "test_configs",
+        "config_invalid_set_filter_task_name.yaml"
+      )
+    ),
+    regexp = 'Specified task filters based on task id variable "not_a_real_task_id" that is not found in the hub'
+  )
+})
 
-test_that(
-  "read_predevals_config fails, invalid eval set n_last",
-  {
-    hub_path <- test_path("testdata", "ecfh")
-    expect_error(
-      read_predevals_config(
-        hub_path,
-        test_path("testdata", "test_configs",
-                  "config_invalid_set_n_last.yaml")
-      ),
-      regexp = "/eval_sets/1/round_filters/n_last must be >= 1"
-    )
-  }
-)
+test_that("read_predevals_config fails, invalid eval set task filter variable value", {
+  hub_path <- test_path("testdata", "ecfh")
+  expect_error(
+    read_predevals_config(
+      hub_path,
+      test_path(
+        "testdata",
+        "test_configs",
+        "config_invalid_set_filter_task_value.yaml"
+      )
+    ),
+    regexp = 'Evaluation set specified invalid filter values on task id variable "location": "not a real location"'
+  )
+})
 
-test_that(
-  "read_predevals_config fails, invalid eval set min_round_id",
-  {
-    hub_path <- test_path("testdata", "ecfh")
-    expect_error(
-      read_predevals_config(
-        hub_path,
-        test_path("testdata", "test_configs",
-                  "config_invalid_set_min_round_id.yaml")
-      ),
-      regexp = 'Minimum round id "THIS IS NOT A ROUND ID" for evaluation set is not a valid round id for the hub.'
-    )
-  }
-)
+test_that("read_predevals_config fails, invalid task_id_text, not a task id variable", {
+  hub_path <- test_path("testdata", "ecfh")
+  expect_error(
+    read_predevals_config(
+      hub_path,
+      test_path(
+        "testdata",
+        "test_configs",
+        "config_invalid_task_id_text_non_task_id.yaml"
+      )
+    ),
+    regexp = 'Specified `task_id_text` for task id variable "NOT_A_REAL_TASK_ID"'
+  )
+})
 
-test_that(
-  "read_predevals_config fails, invalid eval set task filter variable name",
-  {
-    hub_path <- test_path("testdata", "ecfh")
-    expect_error(
-      read_predevals_config(
-        hub_path,
-        test_path("testdata", "test_configs",
-                  "config_invalid_set_filter_task_name.yaml")
-      ),
-      regexp = 'Specified task filters based on task id variable "not_a_real_task_id" that is not found in the hub'
-    )
-  }
-)
+test_that("read_predevals_config fails, invalid task_id_text, missing entries", {
+  hub_path <- test_path("testdata", "ecfh")
+  expect_error(
+    read_predevals_config(
+      hub_path,
+      test_path(
+        "testdata",
+        "test_configs",
+        "config_invalid_task_id_text_missing.yaml"
+      )
+    ),
+    regexp = 'For task id variable "location", missing the following values: "US" and "25"'
+  )
+})
 
-test_that(
-  "read_predevals_config fails, invalid eval set task filter variable value",
-  {
-    hub_path <- test_path("testdata", "ecfh")
-    expect_error(
-      read_predevals_config(
-        hub_path,
-        test_path("testdata", "test_configs",
-                  "config_invalid_set_filter_task_value.yaml")
-      ),
-      regexp = 'Evaluation set specified invalid filter values on task id variable "location": "not a real location"'
-    )
-  }
-)
+test_that("read_predevals_config fails, invalid relative metrics, not a subset of metrics", {
+  hub_path <- test_path("testdata", "ecfh")
+  expect_error(
+    read_predevals_config(
+      hub_path,
+      test_path(
+        "testdata",
+        "test_configs",
+        "config_invalid_rel_metrics_non_metric.yaml"
+      )
+    ),
+    regexp = 'Relative metric not found in the requested metrics: "log_score".'
+  )
+})
 
-test_that(
-  "read_predevals_config fails, invalid task_id_text, not a task id variable",
-  {
-    hub_path <- test_path("testdata", "ecfh")
-    expect_error(
-      read_predevals_config(
-        hub_path,
-        test_path("testdata", "test_configs",
-                  "config_invalid_task_id_text_non_task_id.yaml")
-      ),
-      regexp = 'Specified `task_id_text` for task id variable "NOT_A_REAL_TASK_ID"'
-    )
-  }
-)
-
-test_that(
-  "read_predevals_config fails, invalid task_id_text, missing entries",
-  {
-    hub_path <- test_path("testdata", "ecfh")
-    expect_error(
-      read_predevals_config(
-        hub_path,
-        test_path("testdata", "test_configs",
-                  "config_invalid_task_id_text_missing.yaml")
-      ),
-      regexp = 'For task id variable "location", missing the following values: "US" and "25"'
-    )
-  }
-)
-
-test_that(
-  "read_predevals_config fails, invalid relative metrics, not a subset of metrics",
-  {
-    hub_path <- test_path("testdata", "ecfh")
-    expect_error(
-      read_predevals_config(
-        hub_path,
-        test_path("testdata", "test_configs",
-                  "config_invalid_rel_metrics_non_metric.yaml")
-      ),
-      regexp = 'Relative metric not found in the requested metrics: "log_score".'
-    )
-  }
-)
-
-test_that(
-  "read_predevals_config fails, invalid relative metrics, no baseline",
-  {
-    hub_path <- test_path("testdata", "ecfh")
-    expect_error(
-      read_predevals_config(
-        hub_path,
-        test_path("testdata", "test_configs",
-                  "config_invalid_rel_metrics_no_baseline.yaml")
-      ),
-      regexp = "must have property baseline when property relative_metrics is present"
-    )
-  }
-)
+test_that("read_predevals_config fails, invalid relative metrics, no baseline", {
+  hub_path <- test_path("testdata", "ecfh")
+  expect_error(
+    read_predevals_config(
+      hub_path,
+      test_path(
+        "testdata",
+        "test_configs",
+        "config_invalid_rel_metrics_no_baseline.yaml"
+      )
+    ),
+    regexp = "must have property baseline when property relative_metrics is present"
+  )
+})

--- a/tests/testthat/test-generate_eval_data.R
+++ b/tests/testthat/test-generate_eval_data.R
@@ -1,105 +1,130 @@
-test_that(
-  "generate_eval_data works, integration test, no relative metrics",
-  {
-    out_path <- withr::local_tempdir()
-    hub_path <- test_path("testdata", "ecfh")
-    model_out_tbl <- hubData::connect_hub(hub_path) |>
-      dplyr::collect()
-    oracle_output <- read.csv(
-      test_path("testdata", "ecfh", "target-data", "oracle-output.csv")
-    )
-    oracle_output[["target_end_date"]] <- as.Date(oracle_output[["target_end_date"]])
+test_that("generate_eval_data works, integration test, no relative metrics", {
+  out_path <- withr::local_tempdir()
+  hub_path <- test_path("testdata", "ecfh")
+  model_out_tbl <- hubData::connect_hub(hub_path) |>
+    dplyr::collect()
+  oracle_output <- read.csv(
+    test_path("testdata", "ecfh", "target-data", "oracle-output.csv")
+  )
+  oracle_output[["target_end_date"]] <- as.Date(oracle_output[[
+    "target_end_date"
+  ]])
 
+  generate_eval_data(
+    hub_path = hub_path,
+    config_path = test_path(
+      "testdata",
+      "test_configs",
+      "config_valid_mean_median_quantile.yaml"
+    ),
+    out_path = out_path,
+    oracle_output = oracle_output
+  )
+
+  check_exp_scores_for_set(
+    out_path,
+    "Full season",
+    model_out_tbl,
+    oracle_output
+  )
+  check_exp_scores_for_set(
+    out_path,
+    "Last 5 weeks",
+    model_out_tbl |> dplyr::filter(reference_date >= "2022-12-17"),
+    oracle_output
+  )
+  check_exp_scores_for_set(
+    out_path,
+    "Alabama, positive horizons",
+    model_out_tbl |> dplyr::filter(reference_date >= "2022-12-17"),
+    oracle_output
+  )
+})
+
+test_that("generate_eval_data works, integration test, with relative metrics", {
+  out_path <- withr::local_tempdir()
+  hub_path <- test_path("testdata", "ecfh")
+  model_out_tbl <- hubData::connect_hub(hub_path) |>
+    dplyr::collect()
+  oracle_output <- read.csv(
+    test_path("testdata", "ecfh", "target-data", "oracle-output.csv")
+  )
+  oracle_output[["target_end_date"]] <- as.Date(oracle_output[[
+    "target_end_date"
+  ]])
+
+  generate_eval_data(
+    hub_path = hub_path,
+    config_path = test_path(
+      "testdata",
+      "test_configs",
+      "config_valid_mean_median_quantile_rel.yaml"
+    ),
+    out_path = out_path,
+    oracle_output = oracle_output
+  )
+
+  check_exp_scores_for_set(
+    out_path,
+    "Full season",
+    model_out_tbl,
+    oracle_output,
+    include_rel = TRUE
+  )
+  check_exp_scores_for_set(
+    out_path,
+    "Last 5 weeks",
+    model_out_tbl |> dplyr::filter(reference_date >= "2022-12-17"),
+    oracle_output,
+    include_rel = TRUE
+  )
+  check_exp_scores_for_set(
+    out_path,
+    "Alabama, positive horizons",
+    model_out_tbl |> dplyr::filter(reference_date >= "2022-12-17"),
+    oracle_output,
+    include_rel = TRUE
+  )
+})
+
+test_that("generate_eval_data generates an informative message and partial results if an evaluation set has no data", {
+  out_path <- withr::local_tempdir()
+  hub_path <- test_path("testdata", "ecfh")
+  model_out_tbl <- hubData::connect_hub(hub_path) |>
+    dplyr::collect()
+  oracle_output <- read.csv(
+    test_path("testdata", "ecfh", "target-data", "oracle-output.csv")
+  )
+  oracle_output[["target_end_date"]] <- as.Date(oracle_output[[
+    "target_end_date"
+  ]])
+
+  expect_message(
     generate_eval_data(
       hub_path = hub_path,
-      config_path = test_path("testdata", "test_configs", "config_valid_mean_median_quantile.yaml"),
-      out_path = out_path,
-      oracle_output = oracle_output
-    )
-
-    check_exp_scores_for_set(out_path,
-                             "Full season",
-                             model_out_tbl,
-                             oracle_output)
-    check_exp_scores_for_set(out_path,
-                             "Last 5 weeks",
-                             model_out_tbl |> dplyr::filter(reference_date >= "2022-12-17"),
-                             oracle_output)
-    check_exp_scores_for_set(out_path,
-                             "Alabama, positive horizons",
-                             model_out_tbl |> dplyr::filter(reference_date >= "2022-12-17"),
-                             oracle_output)
-  }
-)
-
-test_that(
-  "generate_eval_data works, integration test, with relative metrics",
-  {
-    out_path <- withr::local_tempdir()
-    hub_path <- test_path("testdata", "ecfh")
-    model_out_tbl <- hubData::connect_hub(hub_path) |>
-      dplyr::collect()
-    oracle_output <- read.csv(
-      test_path("testdata", "ecfh", "target-data", "oracle-output.csv")
-    )
-    oracle_output[["target_end_date"]] <- as.Date(oracle_output[["target_end_date"]])
-
-    generate_eval_data(
-      hub_path = hub_path,
-      config_path = test_path("testdata", "test_configs", "config_valid_mean_median_quantile_rel.yaml"),
-      out_path = out_path,
-      oracle_output = oracle_output
-    )
-
-    check_exp_scores_for_set(out_path,
-                             "Full season",
-                             model_out_tbl,
-                             oracle_output,
-                             include_rel = TRUE)
-    check_exp_scores_for_set(out_path,
-                             "Last 5 weeks",
-                             model_out_tbl |> dplyr::filter(reference_date >= "2022-12-17"),
-                             oracle_output,
-                             include_rel = TRUE)
-    check_exp_scores_for_set(out_path,
-                             "Alabama, positive horizons",
-                             model_out_tbl |> dplyr::filter(reference_date >= "2022-12-17"),
-                             oracle_output,
-                             include_rel = TRUE)
-  }
-)
-
-test_that(
-  "generate_eval_data generates an informative message and partial results if an evaluation set has no data",
-  {
-    out_path <- withr::local_tempdir()
-    hub_path <- test_path("testdata", "ecfh")
-    model_out_tbl <- hubData::connect_hub(hub_path) |>
-      dplyr::collect()
-    oracle_output <- read.csv(
-      test_path("testdata", "ecfh", "target-data", "oracle-output.csv")
-    )
-    oracle_output[["target_end_date"]] <- as.Date(oracle_output[["target_end_date"]])
-
-    expect_message(
-      generate_eval_data(
-        hub_path = hub_path,
-        config_path = test_path("testdata", "test_configs", "config_valid_set_filters_no_data.yaml"),
-        out_path = out_path,
-        oracle_output = oracle_output
+      config_path = test_path(
+        "testdata",
+        "test_configs",
+        "config_valid_set_filters_no_data.yaml"
       ),
-      'No model output data found for target "wk inc flu hosp" in evaluation set "Valid locations with no data in test'
-    )
+      out_path = out_path,
+      oracle_output = oracle_output
+    ),
+    'No model output data found for target "wk inc flu hosp" in evaluation set "Valid locations with no data in test'
+  )
 
-    check_exp_scores_for_set(out_path,
-                             "Full season",
-                             model_out_tbl,
-                             oracle_output,
-                             include_rel = FALSE)
-    check_exp_scores_for_set(out_path,
-                             "Last 5 weeks",
-                             model_out_tbl |> dplyr::filter(reference_date >= "2022-12-17"),
-                             oracle_output,
-                             include_rel = FALSE)
-  }
-)
+  check_exp_scores_for_set(
+    out_path,
+    "Full season",
+    model_out_tbl,
+    oracle_output,
+    include_rel = FALSE
+  )
+  check_exp_scores_for_set(
+    out_path,
+    "Last 5 weeks",
+    model_out_tbl |> dplyr::filter(reference_date >= "2022-12-17"),
+    oracle_output,
+    include_rel = FALSE
+  )
+})

--- a/tests/testthat/test-load_model_out_in_eval_set.R
+++ b/tests/testthat/test-load_model_out_in_eval_set.R
@@ -1,240 +1,221 @@
-test_that(
-  "load_model_out_in_eval_set succeeds, all rounds",
-  {
-    model_out_tbl <- load_model_out_in_eval_set(
-      hub_path = test_path("testdata", "ecfh"),
-      target_id = "wk flu hosp rate category",
-      eval_set = list(
-        eval_set_name = "all"
-      ),
-      rounds_idx = 0
-    )
+test_that("load_model_out_in_eval_set succeeds, all rounds", {
+  model_out_tbl <- load_model_out_in_eval_set(
+    hub_path = test_path("testdata", "ecfh"),
+    target_id = "wk flu hosp rate category",
+    eval_set = list(
+      eval_set_name = "all"
+    ),
+    rounds_idx = 0
+  )
 
-    expected_model_out_tbl <- hubData::connect_hub(
-      test_path("testdata", "ecfh")
+  expected_model_out_tbl <- hubData::connect_hub(
+    test_path("testdata", "ecfh")
+  ) |>
+    dplyr::filter(
+      target == "wk flu hosp rate category"
     ) |>
-      dplyr::filter(
-        target == "wk flu hosp rate category"
-      ) |>
-      dplyr::collect()
+    dplyr::collect()
 
-    expect_df_equal_up_to_order(
-      model_out_tbl,
-      expected_model_out_tbl
-    )
-  }
-)
+  expect_df_equal_up_to_order(
+    model_out_tbl,
+    expected_model_out_tbl
+  )
+})
 
 
-test_that(
-  "load_model_out_in_eval_set succeeds, min only",
-  {
-    model_out_tbl <- load_model_out_in_eval_set(
-      hub_path = test_path("testdata", "ecfh"),
-      target_id = "wk flu hosp rate category",
-      eval_set = list(
-        eval_set_name = "some subset",
-        round_filters = list(
-          min = "2022-11-19"
-        )
-      ),
-      rounds_idx = 0
-    )
+test_that("load_model_out_in_eval_set succeeds, min only", {
+  model_out_tbl <- load_model_out_in_eval_set(
+    hub_path = test_path("testdata", "ecfh"),
+    target_id = "wk flu hosp rate category",
+    eval_set = list(
+      eval_set_name = "some subset",
+      round_filters = list(
+        min = "2022-11-19"
+      )
+    ),
+    rounds_idx = 0
+  )
 
-    expected_model_out_tbl <- hubData::connect_hub(
-      test_path("testdata", "ecfh")
+  expected_model_out_tbl <- hubData::connect_hub(
+    test_path("testdata", "ecfh")
+  ) |>
+    dplyr::filter(
+      target == "wk flu hosp rate category",
+      reference_date >= "2022-11-19"
     ) |>
-      dplyr::filter(
-        target == "wk flu hosp rate category",
-        reference_date >= "2022-11-19"
-      ) |>
-      dplyr::collect()
+    dplyr::collect()
 
-    expect_df_equal_up_to_order(
-      model_out_tbl,
-      expected_model_out_tbl
-    )
-  }
-)
+  expect_df_equal_up_to_order(
+    model_out_tbl,
+    expected_model_out_tbl
+  )
+})
 
 
-test_that(
-  "load_model_out_in_eval_set succeeds, n_last only",
-  {
-    # n_last = 5: we expect 2022-12-17, 2022-12-24, 2022-12-31, 2023-01-07, 2023-01-14
-    model_out_tbl <- load_model_out_in_eval_set(
-      hub_path = test_path("testdata", "ecfh"),
-      target_id = "wk flu hosp rate category",
-      eval_set = list(
-        eval_set_name = "some subset",
-        round_filters = list(
-          n_last = 5
-        )
-      ),
-      rounds_idx = 0
-    )
+test_that("load_model_out_in_eval_set succeeds, n_last only", {
+  # n_last = 5: we expect 2022-12-17, 2022-12-24, 2022-12-31, 2023-01-07, 2023-01-14
+  model_out_tbl <- load_model_out_in_eval_set(
+    hub_path = test_path("testdata", "ecfh"),
+    target_id = "wk flu hosp rate category",
+    eval_set = list(
+      eval_set_name = "some subset",
+      round_filters = list(
+        n_last = 5
+      )
+    ),
+    rounds_idx = 0
+  )
 
-    expected_model_out_tbl <- hubData::connect_hub(
-      test_path("testdata", "ecfh")
+  expected_model_out_tbl <- hubData::connect_hub(
+    test_path("testdata", "ecfh")
+  ) |>
+    dplyr::filter(
+      target == "wk flu hosp rate category",
+      reference_date >= "2022-12-17"
     ) |>
-      dplyr::filter(
-        target == "wk flu hosp rate category",
-        reference_date >= "2022-12-17"
-      ) |>
-      dplyr::collect()
+    dplyr::collect()
 
-    expect_df_equal_up_to_order(
-      model_out_tbl,
-      expected_model_out_tbl
-    )
-    expect_setequal(
-      unique(model_out_tbl$reference_date),
-      c("2022-12-17", "2023-01-14")
-    )
+  expect_df_equal_up_to_order(
+    model_out_tbl,
+    expected_model_out_tbl
+  )
+  expect_setequal(
+    unique(model_out_tbl$reference_date),
+    c("2022-12-17", "2023-01-14")
+  )
 
-    # n_last = 4: we expect 2022-12-24, 2022-12-31, 2023-01-07, 2023-01-14
-    # (but note that ecfh has only 2023-01-14 from this set)
-    model_out_tbl <- load_model_out_in_eval_set(
-      hub_path = test_path("testdata", "ecfh"),
-      target_id = "wk flu hosp rate category",
-      eval_set = list(
-        eval_set_name = "some subset",
-        round_filters = list(
-          n_last = 4
-        )
-      ),
-      rounds_idx = 0
-    )
+  # n_last = 4: we expect 2022-12-24, 2022-12-31, 2023-01-07, 2023-01-14
+  # (but note that ecfh has only 2023-01-14 from this set)
+  model_out_tbl <- load_model_out_in_eval_set(
+    hub_path = test_path("testdata", "ecfh"),
+    target_id = "wk flu hosp rate category",
+    eval_set = list(
+      eval_set_name = "some subset",
+      round_filters = list(
+        n_last = 4
+      )
+    ),
+    rounds_idx = 0
+  )
 
-    expected_model_out_tbl <- hubData::connect_hub(
-      test_path("testdata", "ecfh")
+  expected_model_out_tbl <- hubData::connect_hub(
+    test_path("testdata", "ecfh")
+  ) |>
+    dplyr::filter(
+      target == "wk flu hosp rate category",
+      reference_date >= "2023-01-14"
     ) |>
-      dplyr::filter(
-        target == "wk flu hosp rate category",
-        reference_date >= "2023-01-14"
-      ) |>
-      dplyr::collect()
+    dplyr::collect()
 
-    expect_df_equal_up_to_order(
-      model_out_tbl,
-      expected_model_out_tbl
-    )
-    expect_setequal(
-      unique(model_out_tbl$reference_date),
-      c("2023-01-14")
-    )
-  }
-)
+  expect_df_equal_up_to_order(
+    model_out_tbl,
+    expected_model_out_tbl
+  )
+  expect_setequal(
+    unique(model_out_tbl$reference_date),
+    c("2023-01-14")
+  )
+})
 
 
-test_that(
-  "load_model_out_in_eval_set succeeds, min & n_last, min superceeds",
-  {
-    model_out_tbl <- load_model_out_in_eval_set(
-      hub_path = test_path("testdata", "ecfh"),
-      target_id = "wk flu hosp rate category",
-      eval_set = list(
-        eval_set_name = "some subset",
-        round_filters = list(
-          min = "2023-01-14",
-          n_last = 9
-        )
-      ),
-      rounds_idx = 0
-    )
+test_that("load_model_out_in_eval_set succeeds, min & n_last, min superceeds", {
+  model_out_tbl <- load_model_out_in_eval_set(
+    hub_path = test_path("testdata", "ecfh"),
+    target_id = "wk flu hosp rate category",
+    eval_set = list(
+      eval_set_name = "some subset",
+      round_filters = list(
+        min = "2023-01-14",
+        n_last = 9
+      )
+    ),
+    rounds_idx = 0
+  )
 
-    expected_model_out_tbl <- hubData::connect_hub(
-      test_path("testdata", "ecfh")
+  expected_model_out_tbl <- hubData::connect_hub(
+    test_path("testdata", "ecfh")
+  ) |>
+    dplyr::filter(
+      target == "wk flu hosp rate category",
+      reference_date >= "2023-01-14"
     ) |>
-      dplyr::filter(
-        target == "wk flu hosp rate category",
-        reference_date >= "2023-01-14"
-      ) |>
-      dplyr::collect()
+    dplyr::collect()
 
-    expect_df_equal_up_to_order(
-      model_out_tbl,
-      expected_model_out_tbl
-    )
-    expect_setequal(
-      unique(model_out_tbl$reference_date),
-      c("2023-01-14")
-    )
-  }
-)
+  expect_df_equal_up_to_order(
+    model_out_tbl,
+    expected_model_out_tbl
+  )
+  expect_setequal(
+    unique(model_out_tbl$reference_date),
+    c("2023-01-14")
+  )
+})
 
 
-test_that(
-  "load_model_out_in_eval_set succeeds, min & n_last, n_last superceeds",
-  {
-    model_out_tbl <- load_model_out_in_eval_set(
-      hub_path = test_path("testdata", "ecfh"),
-      target_id = "wk flu hosp rate category",
-      eval_set = list(
-        eval_set_name = "some subset",
-        round_filters = list(
-          min = "2022-11-19", # there are 9 rounds on or after this date
-          n_last = 5
-        )
-      ),
-      rounds_idx = 0
-    )
+test_that("load_model_out_in_eval_set succeeds, min & n_last, n_last superceeds", {
+  model_out_tbl <- load_model_out_in_eval_set(
+    hub_path = test_path("testdata", "ecfh"),
+    target_id = "wk flu hosp rate category",
+    eval_set = list(
+      eval_set_name = "some subset",
+      round_filters = list(
+        min = "2022-11-19", # there are 9 rounds on or after this date
+        n_last = 5
+      )
+    ),
+    rounds_idx = 0
+  )
 
-    expected_model_out_tbl <- hubData::connect_hub(
-      test_path("testdata", "ecfh")
+  expected_model_out_tbl <- hubData::connect_hub(
+    test_path("testdata", "ecfh")
+  ) |>
+    dplyr::filter(
+      target == "wk flu hosp rate category",
+      reference_date >= "2022-12-17"
     ) |>
-      dplyr::filter(
-        target == "wk flu hosp rate category",
-        reference_date >= "2022-12-17"
-      ) |>
-      dplyr::collect()
+    dplyr::collect()
 
-    expect_df_equal_up_to_order(
-      model_out_tbl,
-      expected_model_out_tbl
-    )
-    expect_setequal(
-      unique(model_out_tbl$reference_date),
-      c("2022-12-17", "2023-01-14")
-    )
-  }
-)
+  expect_df_equal_up_to_order(
+    model_out_tbl,
+    expected_model_out_tbl
+  )
+  expect_setequal(
+    unique(model_out_tbl$reference_date),
+    c("2022-12-17", "2023-01-14")
+  )
+})
 
 
-
-test_that(
-  "load_model_out_in_eval_set succeeds, min round and task id filters",
-  {
-    model_out_tbl <- load_model_out_in_eval_set(
-      hub_path = test_path("testdata", "ecfh"),
-      target_id = "wk flu hosp rate category",
-      eval_set = list(
-        eval_set_name = "some subset",
-        round_filters = list(
-          min = "2022-11-19"
-        ),
-        task_filters = list(
-          location = "US",
-          horizon = c(1, 2)
-        )
+test_that("load_model_out_in_eval_set succeeds, min round and task id filters", {
+  model_out_tbl <- load_model_out_in_eval_set(
+    hub_path = test_path("testdata", "ecfh"),
+    target_id = "wk flu hosp rate category",
+    eval_set = list(
+      eval_set_name = "some subset",
+      round_filters = list(
+        min = "2022-11-19"
       ),
-      rounds_idx = 0
-    )
+      task_filters = list(
+        location = "US",
+        horizon = c(1, 2)
+      )
+    ),
+    rounds_idx = 0
+  )
 
-    expected_model_out_tbl <- hubData::connect_hub(
-      test_path("testdata", "ecfh")
+  expected_model_out_tbl <- hubData::connect_hub(
+    test_path("testdata", "ecfh")
+  ) |>
+    dplyr::filter(
+      target == "wk flu hosp rate category",
+      reference_date >= "2022-11-19",
+      location == "US",
+      horizon %in% c(1, 2)
     ) |>
-      dplyr::filter(
-        target == "wk flu hosp rate category",
-        reference_date >= "2022-11-19",
-        location == "US",
-        horizon %in% c(1, 2)
-      ) |>
-      dplyr::collect()
+    dplyr::collect()
 
-    expect_df_equal_up_to_order(
-      model_out_tbl,
-      expected_model_out_tbl
-    )
-  }
-)
+  expect_df_equal_up_to_order(
+    model_out_tbl,
+    expected_model_out_tbl
+  )
+})

--- a/tests/testthat/test-utils-hub_tasks_config.R
+++ b/tests/testthat/test-utils-hub_tasks_config.R
@@ -1,34 +1,58 @@
-test_that(
-  "get_model_tasks succeeds, both rounds_idx = 0 and 1",
-  {
-    hub_path <- test_path("testdata", "ecfh")
-    hub_tasks_config <- hubUtils::read_config(hub_path, config = "tasks")
-    model_task_0 <- get_model_tasks(hub_tasks_config, rounds_idx = 0)
-    expect_length(model_task_0, 3L)
+test_that("get_model_tasks succeeds, both rounds_idx = 0 and 1", {
+  hub_path <- test_path("testdata", "ecfh")
+  hub_tasks_config <- hubUtils::read_config(hub_path, config = "tasks")
+  model_task_0 <- get_model_tasks(hub_tasks_config, rounds_idx = 0)
+  expect_length(model_task_0, 3L)
 
-    model_task_1 <- get_model_tasks(hub_tasks_config, rounds_idx = 1)
-    expect_length(model_task_1, 1L)
-  }
-)
+  model_task_1 <- get_model_tasks(hub_tasks_config, rounds_idx = 1)
+  expect_length(model_task_1, 1L)
+})
 
 
-test_that(
-  "filter_task_groups_to_target works",
-  {
-    task_groups <- list(
+test_that("filter_task_groups_to_target works", {
+  task_groups <- list(
+    list(
+      group_number = 1,
+      target_metadata = list(
+        list(target_id = "target_id_1"),
+        list(target_id = "target_id_2")
+      )
+    ),
+    list(
+      group_number = 2,
+      target_metadata = list(
+        list(target_id = "target_id_3"),
+        list(target_id = "target_id_4"),
+        list(target_id = "target_id_5")
+      )
+    ),
+    list(
+      group_number = 3,
+      target_metadata = list(
+        list(target_id = "target_id_4")
+      )
+    )
+  )
+
+  expect_equal(
+    filter_task_groups_to_target(task_groups, "target_id_1"),
+    list(
       list(
         group_number = 1,
         target_metadata = list(
-          list(target_id = "target_id_1"),
-          list(target_id = "target_id_2")
+          list(target_id = "target_id_1")
         )
-      ),
+      )
+    )
+  )
+
+  expect_equal(
+    filter_task_groups_to_target(task_groups, "target_id_4"),
+    list(
       list(
         group_number = 2,
         target_metadata = list(
-          list(target_id = "target_id_3"),
-          list(target_id = "target_id_4"),
-          list(target_id = "target_id_5")
+          list(target_id = "target_id_4")
         )
       ),
       list(
@@ -38,194 +62,161 @@ test_that(
         )
       )
     )
+  )
 
-    expect_equal(
-      filter_task_groups_to_target(task_groups, "target_id_1"),
-      list(
-        list(
-          group_number = 1,
-          target_metadata = list(
-            list(target_id = "target_id_1")
-          )
+  expect_equal(
+    filter_task_groups_to_target(task_groups, "NOT A REAL TARGET ID"),
+    list()
+  )
+})
+
+
+test_that("get_task_id_values works", {
+  task_groups <- list(
+    list(
+      task_ids = list(
+        horizon = list(required = NULL, optional = 1:4),
+        target = list(
+          required = "target_1",
+          optional = c("target_2", "target_3")
+        )
+      )
+    ),
+    list(
+      task_ids = list(
+        horizon = list(required = NULL, optional = 1:4),
+        target = list(
+          required = "target_3",
+          optional = c("target_4", "target_5")
         )
       )
     )
+  )
 
-    expect_equal(
-      filter_task_groups_to_target(task_groups, "target_id_4"),
-      list(
-        list(
-          group_number = 2,
-          target_metadata = list(
-            list(target_id = "target_id_4")
-          )
+  expect_equal(
+    get_task_id_values(task_groups, "horizon"),
+    1:4
+  )
+  expect_equal(
+    get_task_id_values(task_groups, "target"),
+    c("target_1", "target_2", "target_3", "target_4", "target_5")
+  )
+})
+
+
+test_that("get_output_types works", {
+  task_groups <- list(
+    list(
+      output_type = list(
+        "output_type_1" = "output_type_1_value",
+        "output_type_2" = "output_type_2_value"
+      )
+    ),
+    list(
+      output_type = list(
+        "output_type_2" = "output_type_2_value",
+        "output_type_3" = "output_type_3_value"
+      )
+    ),
+    list(
+      output_type = list(
+        "output_type_3" = "output_type_3_value"
+      )
+    )
+  )
+
+  expect_equal(
+    get_output_types(task_groups),
+    c("output_type_1", "output_type_2", "output_type_3")
+  )
+})
+
+
+test_that("is_target_ordinal works", {
+  task_groups_w_target <- list(
+    list(
+      target_metadata = list(
+        list(target_type = "ordinal")
+      )
+    )
+  )
+
+  expect_true(is_target_ordinal(task_groups_w_target))
+
+  task_groups_w_target <- list(
+    list(
+      target_metadata = list(
+        list(target_type = "nominal")
+      )
+    )
+  )
+
+  expect_false(is_target_ordinal(task_groups_w_target))
+})
+
+
+test_that("get_output_type_ids_for_type works", {
+  # all is well
+  task_groups <- list(
+    list(
+      output_type = list(
+        "quantile" = list(
+          output_type_id = c(0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9)
         ),
-        list(
-          group_number = 3,
-          target_metadata = list(
-            list(target_id = "target_id_4")
-          )
-        )
+        "pmf" = list(output_type_id = c("low", "medium", "high"))
+      )
+    ),
+    list(
+      output_type = list(
+        "quantile" = list(output_type_id = c(0.1, 0.5, 0.9)),
+        "pmf" = list(output_type_id = c("low", "medium", "high"))
       )
     )
+  )
+  expect_equal(
+    get_output_type_ids_for_type(task_groups, "quantile"),
+    c(0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9)
+  )
 
-    expect_equal(
-      filter_task_groups_to_target(task_groups, "NOT A REAL TARGET ID"),
-      list()
-    )
-  }
-)
-
-
-test_that(
-  "get_task_id_values works",
-  {
-    task_groups <- list(
-      list(
-        task_ids = list(
-          horizon = list(required = NULL, optional = 1:4),
-          target = list(required = "target_1", optional = c("target_2", "target_3"))
-        )
-      ),
-      list(
-        task_ids = list(
-          horizon = list(required = NULL, optional = 1:4),
-          target = list(required = "target_3", optional = c("target_4", "target_5"))
-        )
+  # incompatible values: expect an error
+  task_groups <- list(
+    list(
+      output_type = list(
+        "quantile" = list(
+          output_type_id = c(0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8)
+        ),
+        "pmf" = list(output_type_id = c("low", "medium", "high"))
+      )
+    ),
+    list(
+      output_type = list(
+        "quantile" = list(output_type_id = c(0.1, 0.5, 0.9)),
+        "pmf" = list(output_type_id = c("low", "medium", "high"))
       )
     )
+  )
+  expect_error(
+    get_output_type_ids_for_type(task_groups, "quantile"),
+    "have different values across task groups."
+  )
 
-    expect_equal(
-      get_task_id_values(task_groups, "horizon"),
-      1:4
-    )
-    expect_equal(
-      get_task_id_values(task_groups, "target"),
-      c("target_1", "target_2", "target_3", "target_4", "target_5")
-    )
-  }
-)
-
-
-
-test_that(
-  "get_output_types works",
-  {
-    task_groups <- list(
-      list(
-        output_type = list(
-          "output_type_1" = "output_type_1_value",
-          "output_type_2" = "output_type_2_value"
-        )
-      ),
-      list(
-        output_type = list(
-          "output_type_2" = "output_type_2_value",
-          "output_type_3" = "output_type_3_value"
-        )
-      ),
-      list(
-        output_type = list(
-          "output_type_3" = "output_type_3_value"
-        )
+  # incompatible value order: expect an error
+  task_groups <- list(
+    list(
+      output_type = list(
+        "quantile" = list(output_type_id = c(0.9, 0.1, 0.5)),
+        "pmf" = list(output_type_id = c("low", "medium", "high"))
+      )
+    ),
+    list(
+      output_type = list(
+        "quantile" = list(output_type_id = c(0.1, 0.5, 0.9)),
+        "pmf" = list(output_type_id = c("low", "medium", "high"))
       )
     )
-
-    expect_equal(
-      get_output_types(task_groups),
-      c("output_type_1", "output_type_2", "output_type_3")
-    )
-  }
-)
-
-
-test_that(
-  "is_target_ordinal works",
-  {
-    task_groups_w_target <- list(
-      list(
-        target_metadata = list(
-          list(target_type = "ordinal")
-        )
-      )
-    )
-
-    expect_true(is_target_ordinal(task_groups_w_target))
-
-    task_groups_w_target <- list(
-      list(
-        target_metadata = list(
-          list(target_type = "nominal")
-        )
-      )
-    )
-
-    expect_false(is_target_ordinal(task_groups_w_target))
-  }
-)
-
-
-test_that(
-  "get_output_type_ids_for_type works",
-  {
-    # all is well
-    task_groups <- list(
-      list(
-        output_type = list(
-          "quantile" = list(output_type_id = c(0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9)),
-          "pmf" = list(output_type_id = c("low", "medium", "high"))
-        )
-      ),
-      list(
-        output_type = list(
-          "quantile" = list(output_type_id = c(0.1, 0.5, 0.9)),
-          "pmf" = list(output_type_id = c("low", "medium", "high"))
-        )
-      )
-    )
-    expect_equal(
-      get_output_type_ids_for_type(task_groups, "quantile"),
-      c(0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9)
-    )
-
-    # incompatible values: expect an error
-    task_groups <- list(
-      list(
-        output_type = list(
-          "quantile" = list(output_type_id = c(0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8)),
-          "pmf" = list(output_type_id = c("low", "medium", "high"))
-        )
-      ),
-      list(
-        output_type = list(
-          "quantile" = list(output_type_id = c(0.1, 0.5, 0.9)),
-          "pmf" = list(output_type_id = c("low", "medium", "high"))
-        )
-      )
-    )
-    expect_error(
-      get_output_type_ids_for_type(task_groups, "quantile"),
-      "have different values across task groups."
-    )
-
-    # incompatible value order: expect an error
-    task_groups <- list(
-      list(
-        output_type = list(
-          "quantile" = list(output_type_id = c(0.9, 0.1, 0.5)),
-          "pmf" = list(output_type_id = c("low", "medium", "high"))
-        )
-      ),
-      list(
-        output_type = list(
-          "quantile" = list(output_type_id = c(0.1, 0.5, 0.9)),
-          "pmf" = list(output_type_id = c("low", "medium", "high"))
-        )
-      )
-    )
-    expect_error(
-      get_output_type_ids_for_type(task_groups, "quantile"),
-      "have different order across task groups."
-    )
-  }
-)
+  )
+  expect_error(
+    get_output_type_ids_for_type(task_groups, "quantile"),
+    "have different order across task groups."
+  )
+})

--- a/tests/testthat/test-utils-metrics.R
+++ b/tests/testthat/test-utils-metrics.R
@@ -1,70 +1,89 @@
-test_that(
-  "get_metric_name_to_output_type works, no ordinal targets",
-  {
-    task_groups <- list(
-      list(
-        output_type = list(
-          "mean" = list(),
-          "quantile" = list()
-        ),
-        target_metadata = list(
-          list(target_type = "continuous")
-        )
+test_that("get_metric_name_to_output_type works, no ordinal targets", {
+  task_groups <- list(
+    list(
+      output_type = list(
+        "mean" = list(),
+        "quantile" = list()
       ),
-      list(
-        output_type = list(
-          "median" = list()
-        ),
-        target_metadata = list(
-          list(target_type = "continuous")
-        )
+      target_metadata = list(
+        list(target_type = "continuous")
+      )
+    ),
+    list(
+      output_type = list(
+        "median" = list()
       ),
-      list(
-        output_type = list(
-          "pmf" = list()
-        ),
-        target_metadata = list(
-          list(target_type = "nominal")
-        )
+      target_metadata = list(
+        list(target_type = "continuous")
+      )
+    ),
+    list(
+      output_type = list(
+        "pmf" = list()
+      ),
+      target_metadata = list(
+        list(target_type = "nominal")
       )
     )
-    metrics <- c("se_point", "ae_point", "interval_coverage_50", "wis", "ae_median",
-                 "NOT A REAL METRIC", "log_score", "rps")
+  )
+  metrics <- c(
+    "se_point",
+    "ae_point",
+    "interval_coverage_50",
+    "wis",
+    "ae_median",
+    "NOT A REAL METRIC",
+    "log_score",
+    "rps"
+  )
 
-    # note: the "rps" metric is only supported for ordinal pmf targets
-    expect_equal(
-      get_metric_name_to_output_type(task_groups, metrics),
-      data.frame(
-        metric = metrics,
-        output_type = c("mean", "median", "quantile", "quantile", "quantile", NA_character_, "pmf", NA_character_)
+  # note: the "rps" metric is only supported for ordinal pmf targets
+  expect_equal(
+    get_metric_name_to_output_type(task_groups, metrics),
+    data.frame(
+      metric = metrics,
+      output_type = c(
+        "mean",
+        "median",
+        "quantile",
+        "quantile",
+        "quantile",
+        NA_character_,
+        "pmf",
+        NA_character_
       )
     )
-  }
-)
+  )
+})
 
 
-test_that(
-  "get_metric_name_to_output_type works, ordinal target",
-  {
-    task_groups <- list(
-      list(
-        output_type = list(
-          "pmf" = list()
-        ),
-        target_metadata = list(
-          list(target_type = "ordinal")
-        )
+test_that("get_metric_name_to_output_type works, ordinal target", {
+  task_groups <- list(
+    list(
+      output_type = list(
+        "pmf" = list()
+      ),
+      target_metadata = list(
+        list(target_type = "ordinal")
       )
     )
-    metrics <- c("se_point", "ae_point", "interval_coverage_50", "wis", "ae_median",
-                 "NOT A REAL METRIC", "log_score", "rps")
+  )
+  metrics <- c(
+    "se_point",
+    "ae_point",
+    "interval_coverage_50",
+    "wis",
+    "ae_median",
+    "NOT A REAL METRIC",
+    "log_score",
+    "rps"
+  )
 
-    expect_equal(
-      get_metric_name_to_output_type(task_groups, metrics),
-      data.frame(
-        metric = metrics,
-        output_type = c(rep(NA_character_, 6), "pmf", "pmf")
-      )
+  expect_equal(
+    get_metric_name_to_output_type(task_groups, metrics),
+    data.frame(
+      metric = metrics,
+      output_type = c(rep(NA_character_, 6), "pmf", "pmf")
     )
-  }
-)
+  )
+})

--- a/tests/testthat/testdata/create_ecfh.R
+++ b/tests/testthat/testdata/create_ecfh.R
@@ -16,11 +16,15 @@ library(hubData)
 
 hub_path <- testthat::test_path("testdata", "ecfh")
 
-models <- list.dirs(file.path(hub_path, "model-output"),
-                    full.names = FALSE, recursive = FALSE)
+models <- list.dirs(
+  file.path(hub_path, "model-output"),
+  full.names = FALSE,
+  recursive = FALSE
+)
 reference_dates <- list.files(
   file.path(hub_path, "model-output", models[[1]]),
-  full.names = FALSE, recursive = FALSE
+  full.names = FALSE,
+  recursive = FALSE
 ) |>
   substr(1, 10)
 
@@ -36,7 +40,12 @@ for (model in models) {
   }
   for (reference_date in reference_dates) {
     model_out_tbl <- readr::read_csv(
-      file.path(hub_path, "model-output", model, paste0(reference_date, "-", model, ".csv"))
+      file.path(
+        hub_path,
+        "model-output",
+        model,
+        paste0(reference_date, "-", model, ".csv")
+      )
     ) |>
       dplyr::filter(
         location %in% c("US", "01"),
@@ -46,12 +55,19 @@ for (model in models) {
 
     write.csv(
       model_out_tbl,
-      file = file.path(hub_path, "model-output", model_short,
-                       paste0(reference_date, "-", model_short, ".csv")),
+      file = file.path(
+        hub_path,
+        "model-output",
+        model_short,
+        paste0(reference_date, "-", model_short, ".csv")
+      ),
       row.names = FALSE
     )
   }
 }
 
-unlink(file.path(hub_path, "model-output", "Flusight-baseline"), recursive = TRUE)
+unlink(
+  file.path(hub_path, "model-output", "Flusight-baseline"),
+  recursive = TRUE
+)
 unlink(file.path(hub_path, "model-output", "MOBS-GLEAM_FLUH"), recursive = TRUE)

--- a/tests/testthat/testdata/create_exp_score_fixtures.R
+++ b/tests/testthat/testdata/create_exp_score_fixtures.R
@@ -6,7 +6,9 @@ model_out_tbl <- hubData::connect_hub(hub_path) |>
 oracle_output <- read.csv(
   testthat::test_path("testdata", "ecfh", "target-data", "oracle-output.csv")
 )
-oracle_output[["target_end_date"]] <- as.Date(oracle_output[["target_end_date"]])
+oracle_output[["target_end_date"]] <- as.Date(oracle_output[[
+  "target_end_date"
+]])
 
 make_score_fixtures_one_set <- function(set_name, model_out_tbl) {
   # get number of unique levels for each "non-dependent" task id
@@ -18,10 +20,17 @@ make_score_fixtures_one_set <- function(set_name, model_out_tbl) {
   )
   names(n_task_id_levels) <- nondependent_task_ids
 
-  for (by in list(NULL, "location", "reference_date", "horizon", "target_end_date")) {
+  for (by in list(
+    NULL,
+    "location",
+    "reference_date",
+    "horizon",
+    "target_end_date"
+  )) {
     # compute scores using hubEvals
     expected_mean_scores <- hubEvals::score_model_out(
-      model_out_tbl = model_out_tbl |> dplyr::filter(.data[["output_type"]] == "mean"),
+      model_out_tbl = model_out_tbl |>
+        dplyr::filter(.data[["output_type"]] == "mean"),
       oracle_output = oracle_output,
       metrics = "se_point",
       relative_metrics = "se_point",
@@ -32,7 +41,8 @@ make_score_fixtures_one_set <- function(set_name, model_out_tbl) {
       c("model_id", by, "se_point_scaled_relative_skill", "se_point")
     ]
     expected_median_scores <- hubEvals::score_model_out(
-      model_out_tbl = model_out_tbl |> dplyr::filter(.data[["output_type"]] == "median"),
+      model_out_tbl = model_out_tbl |>
+        dplyr::filter(.data[["output_type"]] == "median"),
       oracle_output = oracle_output,
       metrics = "ae_point",
       relative_metrics = "ae_point",
@@ -43,18 +53,30 @@ make_score_fixtures_one_set <- function(set_name, model_out_tbl) {
       c("model_id", by, "ae_point_scaled_relative_skill", "ae_point")
     ]
     expected_quantile_scores <- hubEvals::score_model_out(
-      model_out_tbl = model_out_tbl |> dplyr::filter(.data[["output_type"]] == "quantile"),
+      model_out_tbl = model_out_tbl |>
+        dplyr::filter(.data[["output_type"]] == "quantile"),
       oracle_output = oracle_output,
-      metrics = c("wis", "ae_median", "interval_coverage_50", "interval_coverage_95"),
+      metrics = c(
+        "wis",
+        "ae_median",
+        "interval_coverage_50",
+        "interval_coverage_95"
+      ),
       relative_metrics = c("wis", "ae_median"),
       baseline = "FS-base",
       by = c("model_id", by)
     )
     expected_quantile_scores <- as.data.frame(expected_quantile_scores)[
-      c("model_id", by,
-        "wis_scaled_relative_skill", "wis",
-        "ae_median_scaled_relative_skill", "ae_median",
-        "interval_coverage_50", "interval_coverage_95")
+      c(
+        "model_id",
+        by,
+        "wis_scaled_relative_skill",
+        "wis",
+        "ae_median_scaled_relative_skill",
+        "ae_median",
+        "interval_coverage_50",
+        "interval_coverage_95"
+      )
     ]
     expected_scores <- expected_mean_scores |>
       dplyr::left_join(expected_median_scores, by = c("model_id", by)) |>
@@ -84,9 +106,18 @@ make_score_fixtures_one_set <- function(set_name, model_out_tbl) {
       dir.create(save_path, recursive = TRUE)
     }
 
-    file_name <- paste0("scores_", set_name, ifelse(is.null(by), "", paste0("_by_", by)), ".csv")
+    file_name <- paste0(
+      "scores_",
+      set_name,
+      ifelse(is.null(by), "", paste0("_by_", by)),
+      ".csv"
+    )
     file_name <- gsub(" ", "_", file_name)
-    write.csv(expected_scores, file = file.path(save_path, file_name), row.names = FALSE)
+    write.csv(
+      expected_scores,
+      file = file.path(save_path, file_name),
+      row.names = FALSE
+    )
   }
 }
 


### PR DESCRIPTION
## Summary

Configures [air](https://posit-dev.github.io/air/) for R code formatting, applies it across the codebase, and adds a CI check — matching the [hubverse-wide standard package setup](https://github.com/hubverse-org/hubDevs/blob/main/R/use_hubdev_pkg_actions.R).

- `usethis::use_air()` — adds `air.toml`, `.vscode/{settings,extensions}.json`, updates `.Rbuildignore`.
- `air format .` — reformats existing R/ and tests/ code.
- Adds `posit-dev/setup-air@v1` `format-check` GitHub Action that fails on unformatted code in PRs and pushes to `main`.

The bulk of the diff is mechanical whitespace from running air over the existing codebase for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)