### PR TITLE
Align CI workflows with hubverse-standard setup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# instruct GitHub dependabot to scan github actions for updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    # dependabot automatically checks .github/workflows/ and .github/actions/
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # group all run-of-the mill updates into a single pull request
+    groups:
+      updates:
+        applies-to: version-updates
+        update-types:
+          - patch
+          - minor

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -30,7 +30,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/format-check.yaml
+++ b/.github/workflows/format-check.yaml
@@ -14,10 +14,10 @@ jobs:
     name: format-check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install
-        uses: posit-dev/setup-air@v1
+        uses: posit-dev/setup-air@cf390573ff4fe0f198f35df3a642b1409328d859 # v1
 
       - name: Check
         run: air format . --check

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,7 +15,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/pkgdown-netlify-preview.yaml
+++ b/.github/workflows/pkgdown-netlify-preview.yaml
@@ -27,7 +27,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-tinytex@v2
 
@@ -48,7 +48,7 @@ jobs:
 
       - name: Deploy production to GitHub pages 🚀
         if: contains(env.isPush, 'true')
-        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
         with:
           clean: false
           branch: gh-pages
@@ -64,7 +64,7 @@ jobs:
       - name: Deploy PR preview to Netlify
         if: contains(env.isPush, 'false')
         id: netlify-deploy
-        uses: nwtgck/actions-netlify@v3
+        uses: nwtgck/actions-netlify@4cbaf4c08f1a7bfa537d6113472ef4424e4eb654 # v3.0.0
         with:
           publish-dir: '${{ steps.deploy-dir.outputs.dir }}'
           production-branch: main

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -16,7 +16,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -37,7 +37,7 @@ jobs:
           covr::to_cobertura(cov)
         shell: Rscript {0}
 
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         with:
           # Fail if error if not on PR, or if on PR and token is given
           fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Closes #45.

## Summary

Bring CI workflows into line with the hubverse-standard setup (hubData as reference).

- **Add `.github/dependabot.yml`** — weekly schedule, grouped patch+minor `github-actions` updates, mirroring hubData.
- **Bump `actions/checkout@v4` → `@v6`** across all 5 workflows (format-check, lint, pkgdown-netlify-preview, R-CMD-check, test-coverage).
- **SHA-pin third-party actions** (tag in trailing comment) for supply-chain safety:
  - `posit-dev/setup-air@cf390573… # v1`
  - `JamesIves/github-pages-deploy-action@d92aa235… # v4.8.0` (also a version bump from v4.4.1 to match hubData)
  - `nwtgck/actions-netlify@4cbaf4c0… # v3.0.0`
  - `codecov/codecov-action@b9fd7d16… # v4.6.0`

First-party actions (`actions/*`, `r-lib/actions/*`) remain tag-pinned per hubverse convention.

## Out of scope (handled separately)

While investigating, the failing `test-coverage` run on `main` was traced to a missing `CODECOV_TOKEN`. A hubverse-org-wide `CODECOV_TOKEN` secret has now been added (covers hubData and other repos that were silently failing uploads); this is independent of the workflow changes here.