### PR TITLE
Fix codecov-action v6 renamed inputs (file→files, plugin→plugins)

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -41,8 +41,8 @@ jobs:
         with:
           # Fail if error if not on PR, or if on PR and token is given
           fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}
-          file: ./cobertura.xml
-          plugin: noop
+          files: ./cobertura.xml
+          plugins: noop
           disable_search: true
           token: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
After #49 bumped codecov/codecov-action to v6, the test-coverage workflow started failing on main (run https://github.com/hubverse-org/hubPredEvalsData/actions/runs/25786901221). v6 renamed two inputs:

- `file`   → `files`
- `plugin` → `plugins`

The old names are silently ignored, so no coverage report was uploaded and `fail_ci_if_error: true` failed the run. Updated to match the current upstream r-lib/actions v2 test-coverage example.