### PR TITLE
[v1.1.0 impl] Apply transforms in scoring, emit wide-format scores.csv

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
   * `transform_defaults` — top-level default transform applied to all transformable targets.
   * `targets[*].transform` — per-target transform that overrides `transform_defaults`, or the literal `false` to opt a target out.
   * Supported transform functions: `log_shift`, `sqrt`, `log1p`, `log`, `log10`, `log2`.
+* Configured transforms are now applied during scoring (#40).
+* `scores.csv` is now emitted in wide format, with transformed-scale metrics as `<metric>__<label>`-suffixed columns (e.g. `wis__log`). Setting `append: false` emits only the suffixed columns.
 * Existing v1.0.1 configs continue to validate against v1.1.0 without changes.
 
 # hubPredEvalsData 1.0.0

--- a/R/config.R
+++ b/R/config.R
@@ -340,28 +340,22 @@ validate_target_transforms <- function(predevals_config, task_groups) {
 #' types is an error; an inherited `transform_defaults` on the same is a
 #' warning (the transform is silently skipped at scoring time).
 #'
-#' @importFrom rlang %||%
 #' @noRd
 validate_target_transform <- function(target, task_groups, transform_defaults) {
+  if (is.null(resolve_target_transform(target, transform_defaults))) {
+    return()
+  }
+
+  # `target$transform` is the *raw* per-target value (NULL when inherited from
+  # defaults). Both downstream checks need that distinction:
+  # - args are validated only when an explicit per-target transform is set.
+  # - validate_transform_output_types branches error (explicit) vs warn
+  #   (inherited) on whether `target_transform` is NULL.
   target_transform <- target$transform
-
-  # explicit opt-out: nothing to validate
-  if (isFALSE(target_transform)) {
-    return()
-  }
-
-  # determine whether any transform actually applies to this target
-  effective_transform <- target_transform %||% transform_defaults
-  if (is.null(effective_transform)) {
-    return()
-  }
-
-  # explicit per-target transform set: validate its args
   if (!is.null(target_transform)) {
     validate_transform_args(target_transform, target$target_id)
   }
 
-  # check the target's output types support transformation
   validate_transform_output_types(
     target$target_id,
     task_groups,

--- a/R/generate_eval_data.R
+++ b/R/generate_eval_data.R
@@ -1,10 +1,27 @@
 #' Generate evaluation data for a hub
 #'
+#' Scores each target configured in the predevals config against its oracle
+#' data and writes wide-format score tables to disk.
+#'
 #' @param hub_path A path to the hub.
 #' @param config_path A path to a yaml file that specifies the configuration
 #' options for the evaluation.
 #' @param out_path The directory to write the evaluation data to.
 #' @param oracle_output A data frame of oracle output to use for the evaluation.
+#'
+#' @section Output:
+#' For each `(target, eval_set, disaggregation)` requested in the config, a
+#' `scores.csv` is written under `out_path/<target_id>/<eval_set_name>[/<by>]/`
+#' in wide format, with one row per model per disaggregation key.
+#'
+#' When a target has a configured transform, transformed-scale metrics appear
+#' as `<metric>__<label>`-suffixed columns (e.g. `wis__log`) alongside the
+#' natural-scale columns. Setting `append: false` emits only the suffixed
+#' columns.
+#'
+#' For the full configuration schema, see the JSON Schema files installed
+#' with the package under
+#' `system.file("schema", package = "hubPredEvalsData")`.
 #'
 #' @export
 generate_eval_data <- function(hub_path, config_path, out_path, oracle_output) {
@@ -39,6 +56,7 @@ generate_target_eval_data <- function(
   # adding `NULL` at the beginning will calculate overall scores
   disaggregate_by <- c(list(NULL), as.list(target$disaggregate_by))
   eval_sets <- config$eval_sets
+  transform <- resolve_target_transform(target, config$transform_defaults)
 
   task_groups_w_target <- get_task_groups_w_target(
     hub_path,
@@ -76,7 +94,8 @@ generate_target_eval_data <- function(
         target_id = target_id,
         eval_set_name = eval_set$eval_set_name,
         by = by,
-        out_path = out_path
+        out_path = out_path,
+        transform = transform
       )
     }
   }
@@ -101,7 +120,8 @@ get_and_save_scores <- function(
   target_id,
   eval_set_name,
   by,
-  out_path
+  out_path,
+  transform
 ) {
   # Iterate over the output types and calculate scores for each
   scores <- purrr::map(
@@ -115,7 +135,8 @@ get_and_save_scores <- function(
       target_id = target_id,
       eval_set_name = eval_set_name,
       by = by,
-      output_type = .x
+      output_type = .x,
+      transform = transform
     )
   ) |>
     purrr::reduce(dplyr::left_join, by = c("model_id", by))
@@ -151,6 +172,13 @@ get_and_save_scores <- function(
 
 
 #' Get scores for a target in a given evaluation set for a specific output type.
+#'
+#' If `transform` is set and the output type is transformable
+#' (see `get_transformable_output_types()`), scores are computed with the
+#' scale transformation applied. The hubEvals long-format output (with a
+#' `scale` column when `append = TRUE`) is pivoted to wide format here so that
+#' transformed-scale metrics become label-prefixed columns alongside their
+#' natural-scale counterparts.
 #' @noRd
 get_scores_for_output_type <- function(
   model_out_tbl,
@@ -161,7 +189,8 @@ get_scores_for_output_type <- function(
   target_id,
   eval_set_name,
   by,
-  output_type
+  output_type,
+  transform
 ) {
   metrics <- metric_name_to_output_type$metric[
     metric_name_to_output_type$output_type == output_type
@@ -169,42 +198,129 @@ get_scores_for_output_type <- function(
   if (!is.null(relative_metrics)) {
     relative_metrics <- relative_metrics[relative_metrics %in% metrics]
   }
-  scores <- hubEvals::score_model_out(
+
+  apply_transform <- !is.null(transform) &&
+    output_type %in% get_transformable_output_types()
+  transform_append <- apply_transform && isTRUE(transform$append %||% TRUE)
+  transform_label <- if (apply_transform) get_transform_label(transform)
+  # When `append = TRUE`, scoringutils emits both natural- and transformed-scale
+  # rows keyed by a `scale` column. We must include `"scale"` in `by` so
+  # hubEvals' summarise step (which averages everything not in `by`) doesn't
+  # collapse the two scales together. We then pivot that long format to wide.
+  # With `append = FALSE`, only transformed rows are produced and no `scale`
+  # column is emitted, so there's nothing to keep separated.
+  score_by <- c("model_id", by, if (transform_append) "scale")
+  score_args <- list(
     model_out_tbl = model_out_tbl |>
       dplyr::filter(.data[["output_type"]] == !!output_type),
     oracle_output = oracle_output,
     metrics = metrics,
     relative_metrics = relative_metrics,
     baseline = baseline,
-    by = c("model_id", by)
+    by = score_by
+  )
+  if (apply_transform) {
+    score_args$transform <- get_transform_function(transform$fun)
+    score_args$transform_append <- transform_append
+    score_args$transform_label <- transform_label
+    score_args <- c(score_args, transform$args)
+  }
+  scores <- do.call(hubEvals::score_model_out, score_args)
+
+  scores <- order_relative_metric_cols(
+    scores,
+    score_by,
+    relative_metrics,
+    metrics
   )
 
-  if (!is.null(relative_metrics)) {
-    # Return only the scaled relative metrics, not the unscaled ones
-    rel_skill_colnames <- paste0(relative_metrics, "_relative_skill")
-    scores <- dplyr::select(scores, !dplyr::all_of(rel_skill_colnames))
-
-    # Place scaled relative metric columns before corresponding metric columns
-    # relative_metrics is a subset of metrics
-    ordered_metric_cols <- purrr::map(
-      metrics,
-      function(metric) {
-        c(
-          if (metric %in% relative_metrics) {
-            paste0(metric, "_scaled_relative_skill")
-          } else {
-            NULL
-          },
-          metric
-        )
-      }
-    ) |>
-      unlist()
-    scores <- scores |>
-      dplyr::select(dplyr::all_of(
-        c("model_id", by, ordered_metric_cols)
-      ))
+  if (apply_transform) {
+    scores <- pivot_transformed_scores(
+      scores,
+      by = by,
+      label = transform_label,
+      append = transform_append
+    )
   }
 
   scores
+}
+
+
+#' Drop the unscaled relative-skill columns and reorder metric columns so each
+#' `<metric>_scaled_relative_skill` column appears directly before its base
+#' metric column. Returns `scores` unchanged when `relative_metrics` is `NULL`.
+#' @noRd
+order_relative_metric_cols <- function(
+  scores,
+  id_cols,
+  relative_metrics,
+  metrics
+) {
+  if (is.null(relative_metrics)) {
+    return(scores)
+  }
+
+  rel_skill_colnames <- paste0(relative_metrics, "_relative_skill")
+  scores <- dplyr::select(scores, !dplyr::all_of(rel_skill_colnames))
+
+  ordered_metric_cols <- purrr::map(
+    metrics,
+    function(metric) {
+      c(
+        if (metric %in% relative_metrics) {
+          paste0(metric, "_scaled_relative_skill")
+        } else {
+          NULL
+        },
+        metric
+      )
+    }
+  ) |>
+    unlist()
+
+  dplyr::select(scores, dplyr::all_of(c(id_cols, ordered_metric_cols)))
+}
+
+
+#' Pivot transformed-scale scores into label-suffixed wide-format columns.
+#'
+#' For `append = TRUE`, hubEvals emits one row per `(model_id, by..., scale)`
+#' with `scale` being either `"natural"` or the transform label. We split on
+#' `scale`, suffix the transformed-scale metric columns with `"__<label>"`,
+#' and left-join back to the natural-scale rows so a single row per
+#' `(model_id, by...)` carries both scales.
+#'
+#' For `append = FALSE`, only transformed-scale rows are produced (no `scale`
+#' column) and we simply rename all metric columns with the `"__<label>"`
+#' suffix.
+#'
+#' The double-underscore separator lets downstream tools split a column name
+#' into (base-metric, transform-label) unambiguously, since no current metric
+#' name contains `"__"`.
+#' @noRd
+pivot_transformed_scores <- function(scores, by, label, append) {
+  id_cols <- c("model_id", by)
+  if (!append) {
+    return(suffix_metric_cols(scores, id_cols, label))
+  }
+
+  is_natural <- scores$scale == "natural"
+  keep_cols <- setdiff(names(scores), "scale")
+  natural <- scores[is_natural, keep_cols, drop = FALSE]
+  transformed <- suffix_metric_cols(
+    scores[!is_natural, keep_cols, drop = FALSE],
+    id_cols,
+    label
+  )
+  dplyr::left_join(natural, transformed, by = id_cols)
+}
+
+
+#' Rename non-id columns in `df` by suffixing them with `"__<label>"`.
+#' @noRd
+suffix_metric_cols <- function(df, id_cols, label) {
+  is_metric <- !names(df) %in% id_cols
+  names(df)[is_metric] <- paste0(names(df)[is_metric], "__", label)
+  df
 }

--- a/R/utils-transform.R
+++ b/R/utils-transform.R
@@ -29,7 +29,7 @@ get_transformable_output_types <- function() {
 
 #' Resolve a transform function name to the R function it refers to.
 #'
-#' Allowlist-based dispatch via [.transform_functions].
+#' Allowlist-based dispatch via `.transform_functions`.
 #'
 #' @param name Character scalar: one of the values allowed by the schema
 #'   `transform.fun` enum.
@@ -41,4 +41,41 @@ get_transform_function <- function(name) {
     cli::cli_abort("Unknown transform function {.val {name}}.")
   }
   .transform_functions[[name]]
+}
+
+
+#' Resolve the effective transform for a single target.
+#'
+#' Hierarchical, no-merge resolution:
+#' 1. `target$transform == FALSE` -> opt out, return `NULL`.
+#' 2. `target$transform` set      -> use it entirely (no merging with defaults).
+#' 3. Otherwise                   -> inherit `transform_defaults` (or `NULL`).
+#'
+#' @param target One entry from `config$targets`.
+#' @param transform_defaults The top-level `transform_defaults` (or `NULL`).
+#'
+#' @return A transform config list (with `fun` and optional `args`, `append`,
+#'   `label`), or `NULL` if no transform applies to this target.
+#' @importFrom rlang %||%
+#' @noRd
+resolve_target_transform <- function(target, transform_defaults) {
+  if (isFALSE(target$transform)) {
+    return(NULL)
+  }
+  target$transform %||% transform_defaults
+}
+
+
+#' Get the effective label for a transform config.
+#'
+#' Reflects the same fallback used downstream by `hubEvals::score_model_out()`:
+#' when `label` is unset in the config, the function name stands in. Used both
+#' as the `transform_label` argument to `score_model_out()` and as the
+#' column-name suffix when pivoting transformed-scale scores.
+#'
+#' @param transform A transform config list (with at least `fun`).
+#' @return Character scalar.
+#' @noRd
+get_transform_label <- function(transform) {
+  transform$label %||% transform$fun
 }

--- a/man/generate_eval_data.Rd
+++ b/man/generate_eval_data.Rd
@@ -17,5 +17,22 @@ options for the evaluation.}
 \item{oracle_output}{A data frame of oracle output to use for the evaluation.}
 }
 \description{
-Generate evaluation data for a hub
+Scores each target configured in the predevals config against its oracle
+data and writes wide-format score tables to disk.
 }
+\section{Output}{
+
+For each \verb{(target, eval_set, disaggregation)} requested in the config, a
+\code{scores.csv} is written under \verb{out_path/<target_id>/<eval_set_name>[/<by>]/}
+in wide format, with one row per model per disaggregation key.
+
+When a target has a configured transform, transformed-scale metrics appear
+as \verb{<metric>__<label>}-suffixed columns (e.g. \code{wis__log}) alongside the
+natural-scale columns. Setting \code{append: false} emits only the suffixed
+columns.
+
+For the full configuration schema, see the JSON Schema files installed
+with the package under
+\code{system.file("schema", package = "hubPredEvalsData")}.
+}
+

--- a/tests/testthat/helper-setup_two_target_hub.R
+++ b/tests/testthat/helper-setup_two_target_hub.R
@@ -1,0 +1,85 @@
+#' Build a temporary fixture hub with two transformable targets, derived from
+#' the ecfh hub by duplicating `base_target`'s rows under `new_target`.
+#'
+#' Writes hub files into `hub_path` (which must be a fresh, empty directory,
+#' typically `withr::local_tempdir()`). The duplication covers `tasks.json`,
+#' each `model-output/*.csv`, and `target-data/oracle-output.csv`, so callers
+#' can load the extended oracle from the hub via
+#' `hubData::connect_target_oracle_output()`.
+#'
+#' Used by tests that need two transformable targets to exercise per-target
+#' transform isolation. The ecfh fixture only ships with one such target
+#' (`wk inc flu hosp`), so the second is created by data duplication.
+setup_two_target_hub <- function(
+  hub_path,
+  base_target = "wk inc flu hosp",
+  new_target = "wk inc flu death"
+) {
+  src <- testthat::test_path("testdata", "ecfh")
+  file.copy(
+    list.files(src, full.names = TRUE),
+    hub_path,
+    recursive = TRUE
+  )
+
+  # Add new_target as an allowed value for the `target` task_id and append
+  # a target_metadata entry mirroring base_target's, in every task group
+  # that contains base_target.
+  tasks_path <- file.path(hub_path, "hub-config", "tasks.json")
+  tasks <- jsonlite::read_json(tasks_path, simplifyVector = FALSE)
+  task_groups <- tasks$rounds[[1]]$model_tasks
+  for (i in seq_along(task_groups)) {
+    metas <- task_groups[[i]]$target_metadata
+    base_idx <- which(vapply(
+      metas,
+      function(m) identical(m$target_id, base_target),
+      logical(1)
+    ))
+    if (length(base_idx) == 0) {
+      next
+    }
+
+    task_groups[[i]]$task_ids$target$optional <- c(
+      task_groups[[i]]$task_ids$target$optional,
+      new_target
+    )
+    new_md <- metas[[base_idx]]
+    new_md$target_id <- new_target
+    new_md$target_keys$target <- new_target
+    task_groups[[i]]$target_metadata <- c(metas, list(new_md))
+  }
+  tasks$rounds[[1]]$model_tasks <- task_groups
+  jsonlite::write_json(
+    tasks,
+    tasks_path,
+    auto_unbox = TRUE,
+    pretty = TRUE,
+    null = "null"
+  )
+
+  # Duplicate model-output rows under the new target name.
+  model_out_files <- list.files(
+    file.path(hub_path, "model-output"),
+    pattern = "\\.csv$",
+    recursive = TRUE,
+    full.names = TRUE
+  )
+  for (f in model_out_files) {
+    rows <- read.csv(f, check.names = FALSE)
+    base_rows <- rows[rows$target == base_target, ]
+    if (nrow(base_rows) > 0) {
+      base_rows$target <- new_target
+      utils::write.csv(rbind(rows, base_rows), f, row.names = FALSE)
+    }
+  }
+
+  # Extend the oracle output similarly, writing the result back to disk so
+  # callers can load it via hubData::connect_target_oracle_output().
+  oracle_path <- file.path(hub_path, "target-data", "oracle-output.csv")
+  oracle <- read.csv(oracle_path)
+  base_oracle <- oracle[oracle$target == base_target, ]
+  base_oracle$target <- new_target
+  utils::write.csv(rbind(oracle, base_oracle), oracle_path, row.names = FALSE)
+
+  invisible(hub_path)
+}

--- a/tests/testthat/test-generate_eval_data.R
+++ b/tests/testthat/test-generate_eval_data.R
@@ -87,6 +87,271 @@ test_that("generate_eval_data works, integration test, with relative metrics", {
   )
 })
 
+test_that("generate_eval_data resolves and applies per-target transforms independently across targets", {
+  hub_path <- withr::local_tempdir()
+  out_path <- withr::local_tempdir()
+  config_path <- file.path(hub_path, "predevals-config.yaml")
+  setup_two_target_hub(hub_path)
+  oracle_output <- hubData::connect_target_oracle_output(hub_path) |>
+    dplyr::collect()
+
+  yaml::write_yaml(
+    list(
+      schema_version = paste0(
+        "https://raw.githubusercontent.com/hubverse-org/",
+        "hubPredEvalsData/main/inst/schema/v1.1.0/config_schema.json"
+      ),
+      rounds_idx = 0L,
+      targets = list(
+        list(
+          target_id = "wk inc flu hosp",
+          metrics = list("wis"),
+          transform = list(
+            fun = "log_shift",
+            args = list(offset = 1),
+            append = TRUE
+          )
+        ),
+        list(
+          target_id = "wk inc flu death",
+          metrics = list("wis"),
+          transform = list(
+            fun = "sqrt",
+            append = TRUE
+          )
+        )
+      ),
+      eval_sets = list(list(
+        eval_set_name = "Full season",
+        round_filters = list(min = "2022-10-22")
+      ))
+    ),
+    config_path
+  )
+
+  generate_eval_data(
+    hub_path = hub_path,
+    config_path = config_path,
+    out_path = out_path,
+    oracle_output = oracle_output
+  )
+
+  scores_log <- read.csv(
+    file.path(out_path, "wk inc flu hosp", "Full season", "scores.csv")
+  )
+  expect_true(all(c("wis", "wis__log_shift") %in% names(scores_log)))
+  expect_false("wis__sqrt" %in% names(scores_log))
+
+  scores_sqrt <- read.csv(
+    file.path(out_path, "wk inc flu death", "Full season", "scores.csv")
+  )
+  expect_true(all(c("wis", "wis__sqrt") %in% names(scores_sqrt)))
+  expect_false("wis__log_shift" %in% names(scores_sqrt))
+
+  # The two targets should produce different transformed-scale WIS, confirming
+  # the transforms are not silently aliased to one another.
+  expect_false(
+    isTRUE(all.equal(scores_log$wis__log_shift, scores_sqrt$wis__sqrt))
+  )
+})
+
+
+test_that("generate_eval_data forwards transform args to score_model_out (log_shift offset handles zeros)", {
+  # config_valid_transform_per_target.yaml configures
+  # transform: { fun: log_shift, args: { offset: 1 } } for "wk inc flu hosp".
+  # The ecfh oracle contains true-zero observations for low-incidence
+  # locations. Without the offset, log_shift(0) is -Inf (and scoringutils
+  # emits a "Detected zeros" warning); a finite, warning-free WIS on the
+  # transformed scale is only possible if `args.offset` actually reached
+  # scoringutils::transform_forecasts.
+  out_path <- withr::local_tempdir()
+  hub_path <- test_path("testdata", "ecfh")
+  oracle_output <- hubData::connect_target_oracle_output(hub_path) |>
+    dplyr::collect()
+
+  # Sanity check: there ARE zero observations for the transformed target,
+  # otherwise this test would not exercise the offset.
+  q_obs <- oracle_output$oracle_value[
+    oracle_output$target == "wk inc flu hosp" &
+      oracle_output$output_type == "quantile"
+  ]
+  expect_true(any(q_obs == 0))
+
+  expect_no_warning(
+    generate_eval_data(
+      hub_path = hub_path,
+      config_path = test_path(
+        "testdata",
+        "test_configs",
+        "config_valid_transform_per_target.yaml"
+      ),
+      out_path = out_path,
+      oracle_output = oracle_output
+    ),
+    message = "Detected zeros"
+  )
+
+  scores <- read.csv(
+    file.path(out_path, "wk inc flu hosp", "Full season", "scores.csv")
+  )
+  expect_true(all(is.finite(scores$wis__log)))
+  expect_true(all(is.finite(scores$ae_median__log)))
+})
+
+
+test_that("generate_eval_data applies per-target transform with append=TRUE", {
+  out_path <- withr::local_tempdir()
+  hub_path <- test_path("testdata", "ecfh")
+  oracle_output <- hubData::connect_target_oracle_output(hub_path) |>
+    dplyr::collect()
+
+  generate_eval_data(
+    hub_path = hub_path,
+    config_path = test_path(
+      "testdata",
+      "test_configs",
+      "config_valid_transform_per_target.yaml"
+    ),
+    out_path = out_path,
+    oracle_output = oracle_output
+  )
+
+  natural_metrics <- c(
+    "wis",
+    "ae_median",
+    "interval_coverage_50",
+    "interval_coverage_95"
+  )
+  transformed_metrics <- paste0(natural_metrics, "__log")
+
+  # generate_eval_data emits an overall scores.csv plus one per "by" task_id
+  # the config requests aggregation by. Iterate over all of them to confirm
+  # the transform is applied uniformly at every aggregation level, not just
+  # the overall summary.
+  for (by in list(
+    NULL,
+    "location",
+    "reference_date",
+    "horizon",
+    "target_end_date"
+  )) {
+    scores_dir <- file.path(out_path, "wk inc flu hosp", "Full season")
+    scores_path <- if (is.null(by)) {
+      file.path(scores_dir, "scores.csv")
+    } else {
+      file.path(scores_dir, by, "scores.csv")
+    }
+    expect_true(file.exists(scores_path))
+
+    scores <- read.csv(scores_path)
+    expect_true(all(c(natural_metrics, transformed_metrics) %in% names(scores)))
+    expect_true("n" %in% names(scores))
+    id_cols <- c("model_id", if (!is.null(by)) by)
+    expect_equal(
+      nrow(dplyr::distinct(scores[, id_cols, drop = FALSE])),
+      nrow(scores)
+    )
+    expect_false(any(is.na(scores$wis)))
+    expect_false(any(is.na(scores$wis__log)))
+  }
+
+  # pmf target inherits no transform (no transform_defaults set in this config),
+  # so its scores file has no label-suffixed columns.
+  pmf_scores <- read.csv(
+    file.path(
+      out_path,
+      "wk flu hosp rate category",
+      "Full season",
+      "scores.csv"
+    )
+  )
+  expect_true("log_score" %in% names(pmf_scores))
+  expect_false(any(grepl("__log$", names(pmf_scores))))
+})
+
+
+test_that("generate_eval_data applies transform_defaults to inheriting targets and skips opt-out targets", {
+  out_path <- withr::local_tempdir()
+  hub_path <- test_path("testdata", "ecfh")
+  oracle_output <- hubData::connect_target_oracle_output(hub_path) |>
+    dplyr::collect()
+
+  # The opted-out target ("wk flu hosp rate category") is pmf-only, so it
+  # could not be transformed even if it tried. Without `transform: false`,
+  # validate_transform_output_types would emit an "Inherited transform_defaults
+  # cannot apply" warning here; `transform: false` is what silences it. Check
+  # that explicitly, since the absence of __log_shift columns below would hold
+  # either way for a non-transformable target.
+  expect_no_warning(
+    generate_eval_data(
+      hub_path = hub_path,
+      config_path = test_path(
+        "testdata",
+        "test_configs",
+        "config_valid_transform_defaults.yaml"
+      ),
+      out_path = out_path,
+      oracle_output = oracle_output
+    )
+  )
+
+  # inheriting target gets transform (label inferred from function name -> "log_shift")
+  inheriting <- read.csv(
+    file.path(out_path, "wk inc flu hosp", "Full season", "scores.csv")
+  )
+  expect_true("wis" %in% names(inheriting))
+  expect_true("wis__log_shift" %in% names(inheriting))
+
+  # opted-out target (transform: false) gets no transform applied
+  opted_out <- read.csv(
+    file.path(
+      out_path,
+      "wk flu hosp rate category",
+      "Full season",
+      "scores.csv"
+    )
+  )
+  expect_true("log_score" %in% names(opted_out))
+  expect_false(any(grepl("__log_shift$", names(opted_out))))
+})
+
+
+test_that("generate_eval_data with transform append=FALSE emits only transformed-scale columns", {
+  out_path <- withr::local_tempdir()
+  hub_path <- test_path("testdata", "ecfh")
+  oracle_output <- hubData::connect_target_oracle_output(hub_path) |>
+    dplyr::collect()
+
+  generate_eval_data(
+    hub_path = hub_path,
+    config_path = test_path(
+      "testdata",
+      "test_configs",
+      "config_valid_transform_no_append.yaml"
+    ),
+    out_path = out_path,
+    oracle_output = oracle_output
+  )
+
+  scores <- read.csv(
+    file.path(out_path, "wk inc flu hosp", "Full season", "scores.csv")
+  )
+  expect_true(all(
+    c(
+      "wis__log",
+      "ae_median__log",
+      "interval_coverage_50__log",
+      "interval_coverage_95__log"
+    ) %in%
+      names(scores)
+  ))
+  expect_false(any(
+    c("wis", "ae_median", "interval_coverage_50", "interval_coverage_95") %in%
+      names(scores)
+  ))
+})
+
+
 test_that("generate_eval_data generates an informative message and partial results if an evaluation set has no data", {
   out_path <- withr::local_tempdir()
   hub_path <- test_path("testdata", "ecfh")

--- a/tests/testthat/test-utils-transform.R
+++ b/tests/testthat/test-utils-transform.R
@@ -25,3 +25,55 @@ test_that("get_transform_function errors on an unknown name", {
     regexp = 'Unknown transform function "not_a_function"'
   )
 })
+
+test_that("resolve_target_transform returns NULL when target opts out", {
+  target <- list(transform = FALSE)
+  defaults <- list(fun = "log_shift")
+  expect_null(resolve_target_transform(target, defaults))
+})
+
+test_that("resolve_target_transform returns the per-target transform when set", {
+  target <- list(transform = list(fun = "sqrt", label = "sqrt"))
+  defaults <- list(fun = "log_shift")
+  expect_equal(
+    resolve_target_transform(target, defaults),
+    list(fun = "sqrt", label = "sqrt")
+  )
+})
+
+test_that("resolve_target_transform inherits transform_defaults when target has none", {
+  target <- list()
+  defaults <- list(fun = "log_shift", args = list(offset = 1))
+  expect_equal(
+    resolve_target_transform(target, defaults),
+    defaults
+  )
+})
+
+test_that("resolve_target_transform returns NULL when neither is set", {
+  expect_null(resolve_target_transform(list(), NULL))
+})
+
+test_that("resolve_target_transform: per-target wins entirely; no merge with defaults", {
+  target <- list(transform = list(fun = "sqrt"))
+  defaults <- list(fun = "log_shift", args = list(offset = 1), label = "log")
+  # The defaults' args/label do not bleed into the per-target transform.
+  expect_equal(
+    resolve_target_transform(target, defaults),
+    list(fun = "sqrt")
+  )
+})
+
+test_that("get_transform_label uses configured label when present", {
+  expect_equal(
+    get_transform_label(list(fun = "log_shift", label = "log")),
+    "log"
+  )
+})
+
+test_that("get_transform_label falls back to function name", {
+  expect_equal(
+    get_transform_label(list(fun = "sqrt")),
+    "sqrt"
+  )
+})

--- a/tests/testthat/testdata/test_configs/config_valid_transform_defaults.yaml
+++ b/tests/testthat/testdata/test_configs/config_valid_transform_defaults.yaml
@@ -19,7 +19,6 @@ targets:
 - target_id: wk flu hosp rate category
   metrics:
   - log_score
-  - rps
   transform: false
   disaggregate_by:
   - location
@@ -29,8 +28,8 @@ targets:
 eval_sets:
 - eval_set_name: Full season
   round_filters:
-    min: '2023-01-21'
+    min: '2022-10-22'
 - eval_set_name: Last 4 weeks
   round_filters:
-    min: '2023-01-21'
+    min: '2022-10-22'
     n_last: 4

--- a/tests/testthat/testdata/test_configs/config_valid_transform_no_append.yaml
+++ b/tests/testthat/testdata/test_configs/config_valid_transform_no_append.yaml
@@ -11,16 +11,8 @@ targets:
     fun: log_shift
     args:
       offset: 1
-    append: true
+    append: false
     label: log
-  disaggregate_by:
-  - location
-  - reference_date
-  - horizon
-  - target_end_date
-- target_id: wk flu hosp rate category
-  metrics:
-  - log_score
 eval_sets:
 - eval_set_name: Full season
   round_filters:


### PR DESCRIPTION
Implements the v1.1.0 transform behavior (#40), building on the schema and validation landed in #44 (#39).

## Summary
- Resolves the effective transform for each target via `resolve_target_transform()` (per-target overrides defaults; `false` opts out).
- Passes resolved transforms to `hubEvals::score_model_out()` for transformable output types (`quantile`, `mean`, `median`); non-transformable output types (e.g. `pmf`) are scored on the natural scale regardless.
- Pivots hubEvals' long-format output (with a `scale` column when `append = TRUE`) to wide format: transformed-scale metrics become `<metric>__<label>` columns alongside the natural-scale columns.
- With `append: false`, only the suffixed columns are emitted.
- The double-underscore separator was chosen so downstream tools can split a column name into `(base metric, transform label)` unambiguously: no current metric name contains `__`, while single-underscore metric names (`ae_median`, `interval_coverage_50`, ...) would make a single-`_` separator ambiguous.
- Adds a `setup_two_target_hub()` test helper that derives a two-transformable-target fixture from `ecfh` by duplicating one target's rows. The ecfh fixture only ships one transformable target, so this is the cheapest way to exercise per-target transform isolation across multiple targets.
- Expands the `generate_eval_data()` man page with an Output section covering the file layout and column conventions; points to `system.file("schema", package = "hubPredEvalsData")` for the full config schema.

Closes #40.