### PR TITLE
Score rps on ordinal pmf targets (#48)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,11 @@
 * `scores.csv` is now emitted in wide format, with transformed-scale metrics as `<metric>__<label>`-suffixed columns (e.g. `wis__log`). Setting `append: false` emits only the suffixed columns.
 * Existing v1.0.1 configs continue to validate against v1.1.0 without changes.
 
+## Bug Fixes
+
+* `generate_eval_data()` no longer fails on ordinal pmf targets that request `rps`. The ordinal level order is now read from the hub's `tasks.json` and forwarded to `hubEvals::score_model_out()` so scoringutils dispatches the data as ordinal (#48).
+* `read_predevals_config()` now warns when an ordinal-only pmf metric (e.g. `rps`) is requested against a pre-v4 tasks-schema (where `output_type_id` is split across `required`/`optional`), and errors if the hub's pmf `output_type_id$optional` is non-empty (#48).
+
 # hubPredEvalsData 1.0.0
 
 This is a **breaking change** release that adds support for hubs with multiple rounds.

--- a/R/config.R
+++ b/R/config.R
@@ -189,6 +189,10 @@ validate_config_vs_hub_tasks <- function(hub_path, predevals_config) {
   # checks for per-target transforms (and inherited transform_defaults)
   validate_target_transforms(predevals_config, task_groups)
 
+  # warns / errors when an ordinal-only pmf metric is requested on a pre-v4
+  # tasks-schema (where output_type_id is split across required/optional)
+  validate_ordinal_pmf_dispatch(predevals_config, hub_tasks_config, task_groups)
+
   # checks for eval_sets
   validate_config_eval_sets(
     predevals_config,
@@ -462,6 +466,93 @@ validate_transform_args <- function(transform, target_id) {
         ),
         "i" = cli::format_inline(
           "Allowed argument{?s}: {.val {allowed_args}}."
+        )
+      )
+    )
+  }
+}
+
+
+#' Validate that any ordinal-pmf target requesting an ordinal-only metric
+#' (e.g. `rps`) has unambiguous level ordering in the hub's tasks.json.
+#'
+#' In hubverse tasks-schema v4+, `output_type_id` for pmf is just
+#' `{required: [...]}`, so the array order is the ordinal level order. In
+#' v2/v3, values may be split across `required` and `optional`; the
+#' across-wrapper ordering is undefined. We always read `$required` only at
+#' scoring time, so:
+#' - v4+: silent (the schema and our reader agree).
+#' - v2/v3 with `$optional` null or empty: warn, since we'll silently ignore
+#'   the `$optional` slot that we treat as conventionally empty for pmf.
+#' - v2/v3 with `$optional` populated: error, since levels would be missed.
+#' @noRd
+validate_ordinal_pmf_dispatch <- function(
+  predevals_config,
+  hub_tasks_config,
+  task_groups
+) {
+  schema_version <- hubUtils::extract_schema_version(
+    hub_tasks_config[["schema_version"]]
+  )
+  if (hubUtils::version_gte("v4.0.0", schema_version = schema_version)) {
+    return(invisible())
+  }
+
+  ordinal_metrics <- ordinal_only_pmf_metrics() # nolint: object_usage
+
+  for (target in predevals_config$targets) {
+    target_id <- target$target_id
+    task_groups_w_target <- filter_task_groups_to_target(task_groups, target_id)
+    if (length(task_groups_w_target) == 0) {
+      next # validate_config_targets already errored on this
+    }
+    if (!is_target_ordinal(task_groups_w_target)) {
+      next
+    }
+    requested_ordinal_metrics <- intersect(target$metrics, ordinal_metrics)
+    if (length(requested_ordinal_metrics) == 0) {
+      next
+    }
+
+    # Look for any pmf level the hub put in `$optional`. If we find one we
+    # cannot safely score, because reading `$required` alone would drop it.
+    optional_levels <- unlist(purrr::map(
+      task_groups_w_target,
+      function(task_group) task_group$output_type$pmf$output_type_id$optional
+    ))
+    if (length(optional_levels) > 0) {
+      raise_config_error(
+        c(
+          cli::format_inline(
+            "Cannot score {.val {requested_ordinal_metrics}} on ordinal pmf
+             target {.val {target_id}} under tasks-schema {.val {schema_version}}."
+          ),
+          "x" = cli::format_inline(
+            "{.field output_type_id$optional} for pmf is non-empty
+             ({.val {unique(optional_levels)}}); reading {.field $required}
+             alone would silently drop these levels."
+          ),
+          "i" = paste0(
+            "Bump the hub's tasks-schema to v4.0.0+ (where pmf output_type_id ",
+            "is a single `required` array) to disambiguate ordinal level order."
+          )
+        )
+      )
+    }
+
+    cli::cli_warn(
+      c(
+        cli::format_inline(
+          "Scoring {.val {requested_ordinal_metrics}} on ordinal pmf target
+           {.val {target_id}}: the hub's tasks-schema is
+           {.val {schema_version}} and its pmf
+           {.field output_type_id$optional} is empty, so
+           {.field output_type_id$required} is taken as the ordinal level
+           order."
+        ),
+        "i" = paste0(
+          "Upgrade the hub's tasks-schema to v4.0.0+ to make the level order ",
+          "explicit and silence this warning."
         )
       )
     )

--- a/R/config.R
+++ b/R/config.R
@@ -502,10 +502,9 @@ validate_ordinal_pmf_dispatch <- function(
 
   for (target in predevals_config$targets) {
     target_id <- target$target_id
+    # validate_config_targets() runs earlier in validate_config_vs_hub_tasks()
+    # and errors on any target_id not in the hub, so this always finds a match.
     task_groups_w_target <- filter_task_groups_to_target(task_groups, target_id)
-    if (length(task_groups_w_target) == 0) {
-      next # validate_config_targets already errored on this
-    }
     if (!is_target_ordinal(task_groups_w_target)) {
       next
     }

--- a/R/config.R
+++ b/R/config.R
@@ -527,9 +527,9 @@ validate_ordinal_pmf_dispatch <- function(
              target {.val {target_id}} under tasks-schema {.val {schema_version}}."
           ),
           "x" = cli::format_inline(
-            "{.field output_type_id$optional} for pmf is non-empty
-             ({.val {unique(optional_levels)}}); reading {.field $required}
-             alone would silently drop these levels."
+            "A definitive ordinal level order cannot be determined when
+             {.field output_type_id$optional} is non-empty
+             ({.val {unique(optional_levels)}})."
           ),
           "i" = paste0(
             "Bump the hub's tasks-schema to v4.0.0+ (where pmf output_type_id ",

--- a/R/generate_eval_data.R
+++ b/R/generate_eval_data.R
@@ -95,7 +95,8 @@ generate_target_eval_data <- function(
         eval_set_name = eval_set$eval_set_name,
         by = by,
         out_path = out_path,
-        transform = transform
+        transform = transform,
+        task_groups_w_target = task_groups_w_target
       )
     }
   }
@@ -121,7 +122,8 @@ get_and_save_scores <- function(
   eval_set_name,
   by,
   out_path,
-  transform
+  transform,
+  task_groups_w_target
 ) {
   # Iterate over the output types and calculate scores for each
   scores <- purrr::map(
@@ -136,7 +138,8 @@ get_and_save_scores <- function(
       eval_set_name = eval_set_name,
       by = by,
       output_type = .x,
-      transform = transform
+      transform = transform,
+      task_groups_w_target = task_groups_w_target
     )
   ) |>
     purrr::reduce(dplyr::left_join, by = c("model_id", by))
@@ -190,7 +193,8 @@ get_scores_for_output_type <- function(
   eval_set_name,
   by,
   output_type,
-  transform
+  transform,
+  task_groups_w_target
 ) {
   metrics <- metric_name_to_output_type$metric[
     metric_name_to_output_type$output_type == output_type
@@ -219,6 +223,20 @@ get_scores_for_output_type <- function(
     baseline = baseline,
     by = score_by
   )
+  # Ordinal pmf with a metric that requires ordinal dispatch (e.g. rps): pass
+  # the ordered level vector so scoringutils dispatches as forecast_ordinal
+  # rather than forecast_nominal. log_score works under either dispatch with
+  # identical results, so we skip the lookup when only log_score is requested.
+  if (
+    output_type == "pmf" &&
+      is_target_ordinal(task_groups_w_target) &&
+      any(metrics %in% ordinal_only_pmf_metrics()) # nolint: object_usage
+  ) {
+    score_args$output_type_id_order <- get_output_type_ids_for_type(
+      task_groups_w_target,
+      "pmf"
+    )
+  }
   if (apply_transform) {
     score_args$transform <- get_transform_function(transform$fun)
     score_args$transform_append <- transform_append

--- a/R/utils-hub_tasks_config.R
+++ b/R/utils-hub_tasks_config.R
@@ -96,16 +96,22 @@ is_target_ordinal <- function(task_groups_w_target) {
 }
 
 
-#' Get the output type id values for a given output type. The output type may
-#' appear in multiple task groups, and the output type id values in those groups
-#' may differ as long as there is one group that has all of the output type id
-#' values.
+#' Get the output type id values for a given output type, in the order they
+#' appear in the hub's tasks.json. The output type may appear in multiple task
+#' groups, and the output type id values in those groups may differ as long as
+#' there is one group that has all of the output type id values.
+#'
+#' Reads `output_type_id$required` only. In v4+ tasks-schemas that is the
+#' entire array; in v2/v3 there is also an `$optional` array, but for ordinal
+#' pmf use cases (where this is wired in) `validate_ordinal_pmf_dispatch()`
+#' has already warned (or errored) at config-validation time, so by the time
+#' we get here ignoring `$optional` is the agreed behaviour.
 #' @noRd
 get_output_type_ids_for_type <- function(task_groups, output_type) {
   output_type_ids_by_group <- purrr::map(
     task_groups,
     function(task_group) {
-      task_group$output_type[[output_type]]$output_type_id
+      task_group$output_type[[output_type]]$output_type_id$required
     }
   )
 

--- a/R/utils-metrics.R
+++ b/R/utils-metrics.R
@@ -41,6 +41,19 @@ get_metric_name_to_output_type <- function(task_groups_w_target, metrics) {
 }
 
 
+#' pmf metrics that scoringutils only exposes under ordinal dispatch (i.e. they
+#' appear in `get_metrics(example_ordinal)` but not `get_metrics(example_nominal)`).
+#' Used to decide when we have to resolve and forward `output_type_id_order` to
+#' `score_model_out()`.
+#' @noRd
+ordinal_only_pmf_metrics <- function() {
+  setdiff(
+    names(scoringutils::get_metrics(scoringutils::example_ordinal)),
+    names(scoringutils::get_metrics(scoringutils::example_nominal))
+  )
+}
+
+
 #' Get the standard metrics that are supported for a given output type
 #' @noRd
 get_standard_metrics <- function(output_type, target_is_ordinal) {

--- a/tests/testthat/_snaps/config.md
+++ b/tests/testthat/_snaps/config.md
@@ -28,7 +28,7 @@
       [1] "wk flu hosp rate category"
       
       $targets[[2]]$metrics
-      [1] "log_score" "rps"      
+      [1] "log_score"
       
       $targets[[2]]$disaggregate_by
       [1] "location"        "reference_date"  "horizon"         "target_end_date"
@@ -257,7 +257,7 @@
       [1] "wk flu hosp rate category"
       
       $targets[[1]]$metrics
-      [1] "log_score" "rps"      
+      [1] "log_score"
       
       $targets[[1]]$disaggregate_by
       [1] "location"        "reference_date"  "horizon"         "target_end_date"
@@ -498,7 +498,7 @@
       [1] "wk flu hosp rate category"
       
       $targets[[2]]$metrics
-      [1] "log_score" "rps"      
+      [1] "log_score"
       
       $targets[[2]]$disaggregate_by
       [1] "location"        "reference_date"  "horizon"         "target_end_date"
@@ -801,7 +801,7 @@
       [1] "wk flu hosp rate category"
       
       $targets[[2]]$metrics
-      [1] "log_score" "rps"      
+      [1] "log_score"
       
       $targets[[2]]$disaggregate_by
       [1] "location"        "reference_date"  "horizon"         "target_end_date"
@@ -1042,7 +1042,7 @@
       [1] "wk flu hosp rate category"
       
       $targets[[2]]$metrics
-      [1] "log_score" "rps"      
+      [1] "log_score"
       
       $targets[[2]]$disaggregate_by
       [1] "location"        "reference_date"  "horizon"         "target_end_date"
@@ -1262,7 +1262,7 @@
       [1] "wk flu hosp rate category"
       
       $targets[[2]]$metrics
-      [1] "log_score" "rps"      
+      [1] "log_score"
       
       
       
@@ -1500,7 +1500,7 @@
       [1] "wk flu hosp rate category"
       
       $targets[[2]]$metrics
-      [1] "log_score" "rps"      
+      [1] "log_score"
       
       $targets[[2]]$disaggregate_by
       [1] "location"        "reference_date"  "horizon"         "target_end_date"
@@ -1551,7 +1551,7 @@
       [1] "wk flu hosp rate category"
       
       $targets[[1]]$metrics
-      [1] "log_score" "rps"      
+      [1] "log_score"
       
       $targets[[1]]$disaggregate_by
       [1] "location"        "reference_date"  "horizon"         "target_end_date"
@@ -1733,4 +1733,16 @@
       
       
       
+
+# read_predevals_config warns on ordinal pmf rps under pre-v4 schema
+
+    Scoring "rps" on ordinal pmf target "hosp rate category": the hub's tasks-schema is "v3.0.0" and its pmf output_type_id$optional is empty, so output_type_id$required is taken as the ordinal level order.
+    i Upgrade the hub's tasks-schema to v4.0.0+ to make the level order explicit and silence this warning.
+
+# read_predevals_config errors when pre-v4 ordinal pmf has non-empty $optional
+
+    Error in predevals config file:
+    Cannot score "rps" on ordinal pmf target "hosp rate category" under tasks-schema "v3.0.0".
+    x output_type_id$optional for pmf is non-empty ("very high"); reading $required alone would silently drop these levels.
+    i Bump the hub's tasks-schema to v4.0.0+ (where pmf output_type_id is a single `required` array) to disambiguate ordinal level order.
 

--- a/tests/testthat/_snaps/config.md
+++ b/tests/testthat/_snaps/config.md
@@ -1743,6 +1743,6 @@
 
     Error in predevals config file:
     Cannot score "rps" on ordinal pmf target "hosp rate category" under tasks-schema "v3.0.0".
-    x output_type_id$optional for pmf is non-empty ("very high"); reading $required alone would silently drop these levels.
+    x A definitive ordinal level order cannot be determined when output_type_id$optional is non-empty ("very high").
     i Bump the hub's tasks-schema to v4.0.0+ (where pmf output_type_id is a single `required` array) to disambiguate ordinal level order.
 

--- a/tests/testthat/helper-setup_ordinal_pmf_hub.R
+++ b/tests/testthat/helper-setup_ordinal_pmf_hub.R
@@ -1,0 +1,244 @@
+#' Build a tiny ordinal-pmf hub for #48 regression testing.
+#'
+#' Writes a minimal hub into `hub_path` (a fresh empty dir, typically
+#' `withr::local_tempdir()`): always `hub-config/` (tasks.json, admin.json),
+#' plus the oracle and model-output CSVs when `incl_data = TRUE`.
+#'
+#' Data design: the hub has one ordinal pmf target across 4 bins and one
+#' forecast task per location, each with a single observed outcome. The
+#' observed bins are hand-picked (and distinct) so the good-model / bad-model
+#' forecasts can be built relative to them: good-model concentrates
+#' probability mass near the observed bin, bad-model concentrates it at the
+#' opposite end. That coupling is what lets the test assert
+#' rps(good-model) < rps(bad-model) deterministically.
+#'
+#' Forecast probabilities are powers of 1/2 so each 4-bin forecast sums to
+#' exactly 1.0 in IEEE 754, sidestepping the scoringRules
+#' `<= .Machine$double.eps` tolerance gate (hubEvals#74) that blocks scoring
+#' rps on the ecfh fixture.
+#'
+#' @param hub_path Fresh empty directory to write the hub into.
+#' @param schema_version hubverse tasks-schema version for the hub's
+#'   tasks.json. Only `"v6.0.0"` (default; pmf `output_type_id` is a single
+#'   `required` array) and `"v3.0.0"` (pmf `output_type_id` is split across
+#'   `required` / `optional`) are supported, so tests can exercise both sides
+#'   of the v4 schema boundary.
+#' @param include_optional `"v3.0.0"` only: when `TRUE`, the last pmf level is
+#'   placed in `output_type_id$optional` instead of `$required`, to exercise
+#'   the non-empty-`$optional` error path in `validate_ordinal_pmf_dispatch()`.
+#' @param incl_data When `TRUE` (default), also write the oracle and
+#'   model-output CSVs. Config-validation tests only read `tasks.json`, so
+#'   they pass `FALSE` to skip the unused data files.
+setup_ordinal_pmf_hub <- function(
+  hub_path,
+  schema_version = c("v6.0.0", "v3.0.0"),
+  include_optional = FALSE,
+  incl_data = TRUE
+) {
+  schema_version <- match.arg(schema_version)
+
+  bins <- c("low", "moderate", "high", "very high")
+  locations <- c("A", "B", "C")
+  observed <- c(A = "low", B = "moderate", C = "high")
+  good_forecasts <- list(
+    A = c(0.5, 0.25, 0.125, 0.125),
+    B = c(0.25, 0.5, 0.125, 0.125),
+    C = c(0.125, 0.125, 0.5, 0.25)
+  )
+  bad_forecasts <- list(
+    A = c(0.125, 0.125, 0.25, 0.5),
+    B = c(0.125, 0.125, 0.5, 0.25),
+    C = c(0.5, 0.25, 0.125, 0.125)
+  )
+
+  # pmf output_type_id wrapper shape differs across the v4 schema boundary:
+  # v4+ is a single `required` array; v2/v3 splits values across
+  # `required` / `optional`. `include_optional` exercises the v3 split.
+  pmf_output_type_id <- if (schema_version == "v6.0.0") {
+    list(required = as.list(bins))
+  } else if (include_optional) {
+    list(
+      required = as.list(bins[-length(bins)]),
+      optional = list(bins[[length(bins)]])
+    )
+  } else {
+    list(required = as.list(bins), optional = NULL)
+  }
+
+  dir.create(file.path(hub_path, "hub-config"), recursive = TRUE)
+  if (incl_data) {
+    dir.create(file.path(hub_path, "target-data"), recursive = TRUE)
+    dir.create(
+      file.path(hub_path, "model-output", "good-model"),
+      recursive = TRUE
+    )
+    dir.create(
+      file.path(hub_path, "model-output", "bad-model"),
+      recursive = TRUE
+    )
+  }
+
+  tasks <- list(
+    schema_version = paste0(
+      "https://raw.githubusercontent.com/hubverse-org/schemas/main/",
+      schema_version,
+      "/tasks-schema.json"
+    ),
+    rounds = list(list(
+      round_id_from_variable = TRUE,
+      round_id = "reference_date",
+      model_tasks = list(list(
+        task_ids = list(
+          reference_date = list(
+            required = NULL,
+            optional = list("2024-01-01")
+          ),
+          target = list(required = NULL, optional = list("hosp rate category")),
+          horizon = list(required = NULL, optional = list(0L)),
+          location = list(required = NULL, optional = as.list(locations)),
+          target_end_date = list(
+            required = NULL,
+            optional = list("2024-01-01")
+          )
+        ),
+        output_type = list(
+          pmf = list(
+            output_type_id = pmf_output_type_id,
+            value = list(type = "double", minimum = 0, maximum = 1)
+          )
+        ),
+        target_metadata = list(list(
+          target_id = "hosp rate category",
+          target_name = "hospitalization rate category",
+          target_units = "rate per 100,000 population",
+          target_keys = list(target = "hosp rate category"),
+          target_type = "ordinal",
+          description = "Synthetic ordinal pmf target for #48 regression test.",
+          is_step_ahead = TRUE,
+          time_unit = "week"
+        ))
+      )),
+      submissions_due = list(start = "2024-01-01", end = "2024-01-01")
+    ))
+  )
+  # output_type_id_datatype is a v4+ tasks-schema field; omit it for v3.
+  if (schema_version == "v6.0.0") {
+    tasks$output_type_id_datatype <- "character"
+  }
+  jsonlite::write_json(
+    tasks,
+    file.path(hub_path, "hub-config", "tasks.json"),
+    auto_unbox = TRUE,
+    pretty = TRUE,
+    null = "null"
+  )
+
+  jsonlite::write_json(
+    list(
+      schema_version = paste0(
+        "https://raw.githubusercontent.com/hubverse-org/schemas/",
+        "main/v3.0.0/admin-schema.json"
+      ),
+      name = "Synthetic ordinal pmf hub",
+      maintainer = "test",
+      contact = list(name = "test", email = "test@example.com"),
+      repository_url = "https://example.com",
+      file_format = list("csv"),
+      timezone = "UTC",
+      model_output_dir = "model-output",
+      hub_models = list(),
+      flags = list()
+    ),
+    file.path(hub_path, "hub-config", "admin.json"),
+    auto_unbox = TRUE,
+    pretty = TRUE,
+    null = "null"
+  )
+
+  if (incl_data) {
+    oracle <- purrr::map(locations, function(loc) {
+      data.frame(
+        location = loc,
+        target_end_date = "2024-01-01",
+        target = "hosp rate category",
+        output_type = "pmf",
+        output_type_id = bins,
+        oracle_value = as.integer(bins == observed[[loc]]),
+        stringsAsFactors = FALSE
+      )
+    }) |>
+      purrr::list_rbind()
+    utils::write.csv(
+      oracle,
+      file.path(hub_path, "target-data", "oracle-output.csv"),
+      row.names = FALSE
+    )
+
+    write_model_output <- function(model_id, forecasts) {
+      rows <- purrr::map(locations, function(loc) {
+        data.frame(
+          reference_date = "2024-01-01",
+          location = loc,
+          horizon = 0L,
+          target = "hosp rate category",
+          target_end_date = "2024-01-01",
+          output_type = "pmf",
+          output_type_id = bins,
+          value = forecasts[[loc]],
+          stringsAsFactors = FALSE
+        )
+      }) |>
+        purrr::list_rbind()
+      utils::write.csv(
+        rows,
+        file.path(
+          hub_path,
+          "model-output",
+          model_id,
+          paste0("2024-01-01-", model_id, ".csv")
+        ),
+        row.names = FALSE
+      )
+    }
+    write_model_output("good-model", good_forecasts)
+    write_model_output("bad-model", bad_forecasts)
+  }
+
+  invisible(hub_path)
+}
+
+
+#' Write a predevals config for the synthetic ordinal-pmf hub.
+#'
+#' Companion to `setup_ordinal_pmf_hub()`: targets the `"hosp rate category"`
+#' target that helper creates.
+#'
+#' @param hub_path Hub directory; the config is written to
+#'   `predevals-config.yaml` inside it.
+#' @param metrics Character vector of metrics to request for the target.
+#' @return Path to the written config file.
+write_ordinal_pmf_config <- function(
+  hub_path,
+  metrics = c("log_score", "rps")
+) {
+  config_path <- file.path(hub_path, "predevals-config.yaml")
+  yaml::write_yaml(
+    list(
+      schema_version = paste0(
+        "https://raw.githubusercontent.com/hubverse-org/",
+        "hubPredEvalsData/main/inst/schema/v1.1.0/config_schema.json"
+      ),
+      rounds_idx = 0L,
+      targets = list(list(
+        target_id = "hosp rate category",
+        metrics = as.list(metrics)
+      )),
+      eval_sets = list(list(
+        eval_set_name = "Full",
+        round_filters = list(min = "2024-01-01")
+      ))
+    ),
+    config_path
+  )
+  config_path
+}

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -483,8 +483,8 @@ test_that("read_predevals_config is silent for ordinal pmf with no ordinal-only 
 
 
 test_that("read_predevals_config errors when pre-v4 ordinal pmf has non-empty $optional", {
-  # When a v3 hub puts pmf levels in `$optional`, reading `$required` alone
-  # at scoring time would silently drop them. The validator must refuse.
+  # When a v3 hub puts pmf levels in `$optional`, a definitive ordinal level
+  # order cannot be determined. The validator must refuse.
   # Snapshot the full error text so the exact wording is locked down.
   hub_path <- withr::local_tempdir()
   setup_ordinal_pmf_hub(

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -457,3 +457,42 @@ test_that("read_predevals_config warns, transform_defaults inherited by pmf-only
     regexp = 'Inherited transform_defaults cannot apply to target "wk flu hosp rate category"'
   )
 })
+
+
+test_that("read_predevals_config warns on ordinal pmf rps under pre-v4 schema", {
+  # A v3 hub wraps pmf output_type_id as {required, optional}; scoring reads
+  # $required only, which is correct for pmf in practice but warrants a
+  # warning until the hub bumps to v4+. Snapshot the full warning text so the
+  # exact wording is locked down.
+  hub_path <- withr::local_tempdir()
+  setup_ordinal_pmf_hub(hub_path, schema_version = "v3.0.0", incl_data = FALSE)
+  config_path <- write_ordinal_pmf_config(hub_path)
+  expect_snapshot_warning(read_predevals_config(hub_path, config_path))
+})
+
+
+test_that("read_predevals_config is silent for ordinal pmf with no ordinal-only metric on pre-v4 schema", {
+  # Same v3 hub, same ordinal pmf target, but only log_score (which works
+  # under both nominal and ordinal dispatch) is requested. No level ordering
+  # is needed, so the validator should stay quiet.
+  hub_path <- withr::local_tempdir()
+  setup_ordinal_pmf_hub(hub_path, schema_version = "v3.0.0", incl_data = FALSE)
+  config_path <- write_ordinal_pmf_config(hub_path, metrics = "log_score")
+  expect_no_warning(read_predevals_config(hub_path, config_path))
+})
+
+
+test_that("read_predevals_config errors when pre-v4 ordinal pmf has non-empty $optional", {
+  # When a v3 hub puts pmf levels in `$optional`, reading `$required` alone
+  # at scoring time would silently drop them. The validator must refuse.
+  # Snapshot the full error text so the exact wording is locked down.
+  hub_path <- withr::local_tempdir()
+  setup_ordinal_pmf_hub(
+    hub_path,
+    schema_version = "v3.0.0",
+    include_optional = TRUE,
+    incl_data = FALSE
+  )
+  config_path <- write_ordinal_pmf_config(hub_path)
+  expect_snapshot_error(read_predevals_config(hub_path, config_path))
+})

--- a/tests/testthat/test-generate_eval_data.R
+++ b/tests/testthat/test-generate_eval_data.R
@@ -270,6 +270,50 @@ test_that("generate_eval_data applies per-target transform with append=TRUE", {
 })
 
 
+test_that("generate_eval_data scores rps on ordinal pmf targets (#48)", {
+  # Without output_type_id_order, scoringutils dispatches pmf data as
+  # forecast_nominal and rejects rps with "Must be a subset of {'log_score'}".
+  # generate_eval_data must read the ordinal level order from the hub's
+  # tasks.json and forward it to score_model_out().
+  #
+  # Uses a synthetic hub rather than ecfh because the ecfh pmf rows drift from
+  # summing to exactly 1 by ~2e-8, which scoringRules::rps_probs still rejects
+  # under its `<= .Machine$double.eps` check (tracked at hubEvals#74). Powers
+  # of 1/2 here sum to exactly 1.0 in IEEE 754, so rps actually computes.
+  hub_path <- withr::local_tempdir()
+  out_path <- withr::local_tempdir()
+  setup_ordinal_pmf_hub(hub_path)
+  config_path <- write_ordinal_pmf_config(hub_path)
+
+  oracle_output <- hubData::connect_target_oracle_output(hub_path) |>
+    dplyr::collect()
+
+  expect_no_error(
+    generate_eval_data(
+      hub_path = hub_path,
+      config_path = config_path,
+      out_path = out_path,
+      oracle_output = oracle_output
+    )
+  )
+
+  scores <- read.csv(
+    file.path(out_path, "hosp rate category", "Full", "scores.csv")
+  )
+  expect_true(all(c("log_score", "rps") %in% names(scores)))
+  expect_true(all(is.finite(scores$log_score)))
+  expect_true(all(is.finite(scores$rps)))
+
+  # good-model concentrates mass at the truth bin; bad-model concentrates at
+  # the opposite end. If output_type_id_order were dropped, mis-ordered, or
+  # reversed, this comparison would no longer reflect the underlying skill.
+  good <- scores[scores$model_id == "good-model", ]
+  bad <- scores[scores$model_id == "bad-model", ]
+  expect_lt(good$rps, bad$rps)
+  expect_lt(good$log_score, bad$log_score)
+})
+
+
 test_that("generate_eval_data applies transform_defaults to inheriting targets and skips opt-out targets", {
   out_path <- withr::local_tempdir()
   hub_path <- test_path("testdata", "ecfh")

--- a/tests/testthat/test-utils-hub_tasks_config.R
+++ b/tests/testthat/test-utils-hub_tasks_config.R
@@ -155,45 +155,47 @@ test_that("is_target_ordinal works", {
 })
 
 
-test_that("get_output_type_ids_for_type works", {
-  # all is well
-  task_groups <- list(
+#' Build a task_groups list with the v4+ output_type_id wrapper shape
+#' (`{required: [...]}`) that `get_output_type_ids_for_type()` reads. Each
+#' `...` arg is a named list `output_type = c(values)` per group.
+make_task_groups <- function(...) {
+  lapply(list(...), function(group) {
     list(
-      output_type = list(
-        "quantile" = list(
-          output_type_id = c(0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9)
-        ),
-        "pmf" = list(output_type_id = c("low", "medium", "high"))
-      )
+      output_type = lapply(group, function(values) {
+        list(output_type_id = list(required = values))
+      })
+    )
+  })
+}
+
+
+test_that("get_output_type_ids_for_type works", {
+  task_groups <- make_task_groups(
+    list(
+      quantile = c(0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9),
+      pmf = c("low", "medium", "high")
     ),
     list(
-      output_type = list(
-        "quantile" = list(output_type_id = c(0.1, 0.5, 0.9)),
-        "pmf" = list(output_type_id = c("low", "medium", "high"))
-      )
+      quantile = c(0.1, 0.5, 0.9),
+      pmf = c("low", "medium", "high")
     )
   )
   expect_equal(
     get_output_type_ids_for_type(task_groups, "quantile"),
     c(0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9)
   )
+  expect_equal(
+    get_output_type_ids_for_type(task_groups, "pmf"),
+    c("low", "medium", "high")
+  )
 
   # incompatible values: expect an error
-  task_groups <- list(
+  task_groups <- make_task_groups(
     list(
-      output_type = list(
-        "quantile" = list(
-          output_type_id = c(0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8)
-        ),
-        "pmf" = list(output_type_id = c("low", "medium", "high"))
-      )
+      quantile = c(0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8),
+      pmf = c("low", "medium", "high")
     ),
-    list(
-      output_type = list(
-        "quantile" = list(output_type_id = c(0.1, 0.5, 0.9)),
-        "pmf" = list(output_type_id = c("low", "medium", "high"))
-      )
-    )
+    list(quantile = c(0.1, 0.5, 0.9), pmf = c("low", "medium", "high"))
   )
   expect_error(
     get_output_type_ids_for_type(task_groups, "quantile"),
@@ -201,19 +203,12 @@ test_that("get_output_type_ids_for_type works", {
   )
 
   # incompatible value order: expect an error
-  task_groups <- list(
+  task_groups <- make_task_groups(
     list(
-      output_type = list(
-        "quantile" = list(output_type_id = c(0.9, 0.1, 0.5)),
-        "pmf" = list(output_type_id = c("low", "medium", "high"))
-      )
+      quantile = c(0.9, 0.1, 0.5),
+      pmf = c("low", "medium", "high")
     ),
-    list(
-      output_type = list(
-        "quantile" = list(output_type_id = c(0.1, 0.5, 0.9)),
-        "pmf" = list(output_type_id = c("low", "medium", "high"))
-      )
-    )
+    list(quantile = c(0.1, 0.5, 0.9), pmf = c("low", "medium", "high"))
   )
   expect_error(
     get_output_type_ids_for_type(task_groups, "quantile"),

--- a/tests/testthat/testdata/test_configs/config_invalid_set_filter_task_name.yaml
+++ b/tests/testthat/testdata/test_configs/config_invalid_set_filter_task_name.yaml
@@ -15,7 +15,6 @@ targets:
 - target_id: wk flu hosp rate category
   metrics:
   - log_score
-  - rps
   disaggregate_by:
   - location
   - reference_date

--- a/tests/testthat/testdata/test_configs/config_invalid_set_filter_task_value.yaml
+++ b/tests/testthat/testdata/test_configs/config_invalid_set_filter_task_value.yaml
@@ -15,7 +15,6 @@ targets:
 - target_id: wk flu hosp rate category
   metrics:
   - log_score
-  - rps
   disaggregate_by:
   - location
   - reference_date

--- a/tests/testthat/testdata/test_configs/config_invalid_set_min_round_id.yaml
+++ b/tests/testthat/testdata/test_configs/config_invalid_set_min_round_id.yaml
@@ -15,7 +15,6 @@ targets:
 - target_id: wk flu hosp rate category
   metrics:
   - log_score
-  - rps
   disaggregate_by:
   - location
   - reference_date

--- a/tests/testthat/testdata/test_configs/config_invalid_task_id_text_missing.yaml
+++ b/tests/testthat/testdata/test_configs/config_invalid_task_id_text_missing.yaml
@@ -15,7 +15,6 @@ targets:
 - target_id: wk flu hosp rate category
   metrics:
   - log_score
-  - rps
   disaggregate_by:
   - location
   - reference_date

--- a/tests/testthat/testdata/test_configs/config_invalid_task_id_text_non_task_id.yaml
+++ b/tests/testthat/testdata/test_configs/config_invalid_task_id_text_non_task_id.yaml
@@ -15,7 +15,6 @@ targets:
 - target_id: wk flu hosp rate category
   metrics:
   - log_score
-  - rps
   disaggregate_by:
   - location
   - reference_date

--- a/tests/testthat/testdata/test_configs/config_valid.yaml
+++ b/tests/testthat/testdata/test_configs/config_valid.yaml
@@ -15,7 +15,6 @@ targets:
 - target_id: wk flu hosp rate category
   metrics:
   - log_score
-  - rps
   disaggregate_by:
   - location
   - reference_date

--- a/tests/testthat/testdata/test_configs/config_valid_no_disaggregate_by.yaml
+++ b/tests/testthat/testdata/test_configs/config_valid_no_disaggregate_by.yaml
@@ -10,7 +10,6 @@ targets:
 - target_id: wk flu hosp rate category
   metrics:
   - log_score
-  - rps
 eval_sets:
 - eval_set_name: Full season
   round_filters:

--- a/tests/testthat/testdata/test_configs/config_valid_no_min_round_id.yaml
+++ b/tests/testthat/testdata/test_configs/config_valid_no_min_round_id.yaml
@@ -15,7 +15,6 @@ targets:
 - target_id: wk flu hosp rate category
   metrics:
   - log_score
-  - rps
   disaggregate_by:
   - location
   - reference_date

--- a/tests/testthat/testdata/test_configs/config_valid_no_task_id_text.yaml
+++ b/tests/testthat/testdata/test_configs/config_valid_no_task_id_text.yaml
@@ -15,7 +15,6 @@ targets:
 - target_id: wk flu hosp rate category
   metrics:
   - log_score
-  - rps
   disaggregate_by:
   - location
   - reference_date

--- a/tests/testthat/testdata/test_configs/config_valid_rel_metrics.yaml
+++ b/tests/testthat/testdata/test_configs/config_valid_rel_metrics.yaml
@@ -19,7 +19,6 @@ targets:
 - target_id: wk flu hosp rate category
   metrics:
   - log_score
-  - rps
   disaggregate_by:
   - location
   - reference_date

--- a/tests/testthat/testdata/test_configs/config_valid_rounds_idx_1.yaml
+++ b/tests/testthat/testdata/test_configs/config_valid_rounds_idx_1.yaml
@@ -4,7 +4,6 @@ targets:
 - target_id: wk flu hosp rate category
   metrics:
   - log_score
-  - rps
   disaggregate_by:
   - location
   - reference_date

--- a/tests/testthat/testdata/test_configs/config_valid_set_filters.yaml
+++ b/tests/testthat/testdata/test_configs/config_valid_set_filters.yaml
@@ -15,7 +15,6 @@ targets:
 - target_id: wk flu hosp rate category
   metrics:
   - log_score
-  - rps
   disaggregate_by:
   - location
   - reference_date

--- a/tests/testthat/testdata/test_configs/config_valid_two_rounds.yaml
+++ b/tests/testthat/testdata/test_configs/config_valid_two_rounds.yaml
@@ -4,7 +4,6 @@ targets:
 - target_id: wk flu hosp rate category
   metrics:
   - log_score
-  - rps
   disaggregate_by:
   - location
   - reference_date

--- a/tests/testthat/testdata/test_configs/config_warn_transform_pmf_inherited.yaml
+++ b/tests/testthat/testdata/test_configs/config_warn_transform_pmf_inherited.yaml
@@ -11,7 +11,6 @@ targets:
 - target_id: wk flu hosp rate category
   metrics:
   - log_score
-  - rps
 eval_sets:
 - eval_set_name: Full season
   round_filters:


### PR DESCRIPTION
## Summary

Fixes #48. `generate_eval_data()` failed on ordinal pmf targets that request `rps`: it never forwarded `output_type_id_order` to `hubEvals::score_model_out()`, so scoringutils dispatched the data as nominal and rejected `rps` at validation.

## Changes

**Core fix** — `generate_eval_data()` now resolves the ordinal level order from the hub's `tasks.json` (`output_type_id$required`) and forwards it to `score_model_out()` when an ordinal-only metric is requested. `log_score`-only requests skip the lookup, since nominal and ordinal dispatch produce identical `log_score`.

**Latent helper repaired** — `get_output_type_ids_for_type()` was reading a flat-vector shape that no hubverse tasks-schema version actually uses; its unit tests mocked a shape that never existed, so it had green coverage but had never run against a real hub config. It now reads `output_type_id$required`, matching v4+ schemas.

**Config validation** — new `validate_ordinal_pmf_dispatch()` runs at `read_predevals_config()` time: warns when an ordinal-only pmf metric is requested against a pre-v4 tasks-schema, and errors when the hub's pmf `output_type_id$optional` is non-empty (reading `$required` alone would silently drop levels).

**Test-framework changes (look unrelated, aren't)**
- New `helper-setup_ordinal_pmf_hub.R` builds a synthetic ordinal-pmf hub at tasks-schema **v6.0.0** (default, used by the rps tests), with a `schema_version = "v3.0.0"` option so the config-validation tests can exercise the pre-v4 `output_type_id$required`/`$optional` split. Synthetic (vs. using `ecfh`) because `ecfh`'s pmf rows drift from summing to exactly 1 by ~2e-8, which `scoringRules::rps_probs` rejects under its `<= .Machine$double.eps` tolerance check (upstream: hubverse-org/hubEvals#74). Forecast probabilities are powers of 1/2 so each row sums to exactly 1.0.
- Removed incidental `rps` cargo from 14 fixture configs where it was copy-paste baggage, not the point of the test — otherwise the new validator's warning leaked into unrelated snapshot tests.
- `get_output_type_ids_for_type()` test mocks realigned to the real v4+ schema shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)