### PR TITLE
Drop `Remotes:`, use `Additional_repositories:` for hubverse r-universe

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -43,6 +43,7 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::rcmdcheck
+          extra-repositories: 'https://hubverse-org.r-universe.dev'
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -39,11 +39,11 @@ jobs:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
+          extra-repositories: 'https://hubverse-org.r-universe.dev'
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::rcmdcheck
-          extra-repositories: 'https://hubverse-org.r-universe.dev'
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,11 +20,11 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
+          extra-repositories: 'https://hubverse-org.r-universe.dev'
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::lintr, local::.
-          extra-repositories: 'https://hubverse-org.r-universe.dev'
           needs: lint
 
       - name: Lint

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -24,6 +24,7 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::lintr, local::.
+          extra-repositories: 'https://hubverse-org.r-universe.dev'
           needs: lint
 
       - name: Lint

--- a/.github/workflows/pkgdown-netlify-preview.yaml
+++ b/.github/workflows/pkgdown-netlify-preview.yaml
@@ -36,11 +36,11 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
+          extra-repositories: 'https://hubverse-org.r-universe.dev'
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::pkgdown, local::.
-          extra-repositories: 'https://hubverse-org.r-universe.dev'
           needs: website
 
       - name: Build site

--- a/.github/workflows/pkgdown-netlify-preview.yaml
+++ b/.github/workflows/pkgdown-netlify-preview.yaml
@@ -40,6 +40,7 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::pkgdown, local::.
+          extra-repositories: 'https://hubverse-org.r-universe.dev'
           needs: website
 
       - name: Build site

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -25,6 +25,7 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::covr, any::xml2
+          extra-repositories: 'https://hubverse-org.r-universe.dev'
           needs: coverage
 
       - name: Test coverage

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -21,11 +21,11 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
+          extra-repositories: 'https://hubverse-org.r-universe.dev'
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::covr, any::xml2
-          extra-repositories: 'https://hubverse-org.r-universe.dev'
           needs: coverage
 
       - name: Test coverage

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,13 +17,9 @@ Imports:
     jsonvalidate,
     purrr,
     rlang,
-    scoringutils (>= 2.0.0.9000),
+    scoringutils (>= 2.2.0),
     yaml
-Remotes:
-    hubverse-org/hubData,
-    hubverse-org/hubEvals,
-    hubverse-org/hubUtils,
-    epiforecasts/scoringutils
+Additional_repositories: https://hubverse-org.r-universe.dev
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.3


### PR DESCRIPTION
Closes #55, closes #24.

Switches our hubverse deps from GitHub dev versions to r-universe released versions, so CI and docker resolve against stable releases instead of upstream `HEAD`.

- `DESCRIPTION`: drop `Remotes:`, add `Additional_repositories: https://hubverse-org.r-universe.dev`, bump `scoringutils` minimum off its `.9000` dev pin to `>= 2.2.0`.
- Workflows: add `extra-repositories` to each `setup-r` step (pak doesn't honour `Additional_repositories:` on its own, so CI needs the explicit nudge).

See #55 for full rationale.