### PR TITLE
Adds an optional `initial_sort_column` field to the v1.1.0 config schema, plus validation

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -603,7 +603,10 @@ validate_config_task_id_text <- function(
 
 #' Validate the initial_sort_column in a predevals config object.
 #' Checks that the value, if specified, is one of the columns that appear in
-#' the output scores table for at least one target.
+#' the output scores table for at least one target. Valid columns are the union
+#' across all targets (not the intersection), because the downstream predevals
+#' app handles a missing sort column at render time and falls back gracefully
+#' when a configured column is absent from a particular target's scores table.
 #' @noRd
 validate_config_initial_sort_column <- function(predevals_config) {
   initial_sort_column <- predevals_config$initial_sort_column

--- a/R/config.R
+++ b/R/config.R
@@ -199,6 +199,9 @@ validate_config_vs_hub_tasks <- function(hub_path, predevals_config) {
 
   # checks for task_id_text
   validate_config_task_id_text(predevals_config, task_groups, task_id_names)
+
+  # checks for initial_sort_column
+  validate_config_initial_sort_column(predevals_config)
 }
 
 
@@ -594,6 +597,50 @@ validate_config_task_id_text <- function(
         )
       )
     }
+  }
+}
+
+
+#' Validate the initial_sort_column in a predevals config object.
+#' Checks that the value, if specified, is one of the columns that appear in
+#' the output scores table for at least one target.
+#' @noRd
+validate_config_initial_sort_column <- function(predevals_config) {
+  initial_sort_column <- predevals_config$initial_sort_column
+  if (is.null(initial_sort_column)) {
+    return()
+  }
+
+  valid_columns <- c("model_id", "n")
+  for (target in predevals_config$targets) {
+    metrics <- target$metrics
+    valid_columns <- c(valid_columns, metrics)
+    if (!is.null(target$relative_metrics)) {
+      valid_columns <- c(
+        valid_columns,
+        paste0(target$relative_metrics, "_scaled_relative_skill")
+      )
+    }
+    if (!is.null(target$disaggregate_by)) {
+      valid_columns <- c(valid_columns, target$disaggregate_by)
+    }
+  }
+  valid_columns <- unique(valid_columns)
+
+  if (!initial_sort_column %in% valid_columns) {
+    raise_config_error(
+      c(
+        cli::format_inline(
+          "Invalid `initial_sort_column` value {.val {initial_sort_column}}."
+        ),
+        "i" = cli::format_inline(
+          "Must be one of the output scores table columns."
+        ),
+        "x" = cli::format_inline(
+          "Valid columns: {.val {valid_columns}}."
+        )
+      )
+    )
   }
 }
 

--- a/inst/schema/v1.1.0/config_schema.json
+++ b/inst/schema/v1.1.0/config_schema.json
@@ -173,7 +173,7 @@
             "minimum": 0
         },
         "initial_sort_column": {
-            "description": "Optional column name to use as the initial sort column in the predevals scores table. Must be one of the columns in the output scores table (e.g. \"model_id\", \"wis\", \"n\").",
+            "description": "Optional column name to use as the initial sort column in the predevals scores table. Must be one of the columns in the output scores table (e.g. \"model_id\", \"wis\", \"n\"). Relative skill metrics appear as \"<metric>_scaled_relative_skill\" (e.g. \"wis_scaled_relative_skill\").",
             "type": "string",
             "minLength": 1
         }

--- a/inst/schema/v1.1.0/config_schema.json
+++ b/inst/schema/v1.1.0/config_schema.json
@@ -171,6 +171,11 @@
             "description": "Required 0-based index of the `rounds` entry to use for evaluation.",
             "type": "integer",
             "minimum": 0
+        },
+        "initial_sort_column": {
+            "description": "Optional column name to use as the initial sort column in the predevals scores table. Must be one of the columns in the output scores table (e.g. \"model_id\", \"wis\", \"n\").",
+            "type": "string",
+            "minLength": 1
         }
     },
     "required": [

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -486,3 +486,48 @@ test_that("read_predevals_config fails, invalid initial_sort_column", {
     regexp = 'Invalid `initial_sort_column` value "not_a_column"'
   )
 })
+
+test_that("read_predevals_config succeeds, initial_sort_column is scaled relative skill column", {
+  hub_path <- test_path("testdata", "ecfh")
+  expect_no_error(
+    read_predevals_config(
+      hub_path,
+      test_path(
+        "testdata",
+        "test_configs",
+        "config_valid_initial_sort_column_scaled_rel.yaml"
+      )
+    )
+  )
+})
+
+test_that("read_predevals_config succeeds, initial_sort_column is disaggregate_by column", {
+  hub_path <- test_path("testdata", "ecfh")
+  expect_no_error(
+    read_predevals_config(
+      hub_path,
+      test_path(
+        "testdata",
+        "test_configs",
+        "config_valid_initial_sort_column_disaggregate_by.yaml"
+      )
+    )
+  )
+})
+
+test_that("read_predevals_config succeeds, initial_sort_column valid for one target but not all", {
+  # ae_median is only present in wk inc flu hosp, not wk flu hosp rate category.
+  # Validation uses a union of columns across targets; predevals handles the
+  # missing column gracefully at render time.
+  hub_path <- test_path("testdata", "ecfh")
+  expect_no_error(
+    read_predevals_config(
+      hub_path,
+      test_path(
+        "testdata",
+        "test_configs",
+        "config_valid_initial_sort_column_cross_target.yaml"
+      )
+    )
+  )
+})

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -457,3 +457,32 @@ test_that("read_predevals_config warns, transform_defaults inherited by pmf-only
     regexp = 'Inherited transform_defaults cannot apply to target "wk flu hosp rate category"'
   )
 })
+
+test_that("read_predevals_config succeeds, valid initial_sort_column", {
+  hub_path <- test_path("testdata", "ecfh")
+  expect_no_error(
+    read_predevals_config(
+      hub_path,
+      test_path(
+        "testdata",
+        "test_configs",
+        "config_valid_initial_sort_column.yaml"
+      )
+    )
+  )
+})
+
+test_that("read_predevals_config fails, invalid initial_sort_column", {
+  hub_path <- test_path("testdata", "ecfh")
+  expect_error(
+    read_predevals_config(
+      hub_path,
+      test_path(
+        "testdata",
+        "test_configs",
+        "config_invalid_initial_sort_column.yaml"
+      )
+    ),
+    regexp = 'Invalid `initial_sort_column` value "not_a_column"'
+  )
+})

--- a/tests/testthat/testdata/test_configs/config_invalid_initial_sort_column.yaml
+++ b/tests/testthat/testdata/test_configs/config_invalid_initial_sort_column.yaml
@@ -1,0 +1,14 @@
+schema_version: https://raw.githubusercontent.com/hubverse-org/hubPredEvalsData/main/inst/schema/v1.1.0/config_schema.json
+rounds_idx: 0
+initial_sort_column: not_a_column
+targets:
+- target_id: wk inc flu hosp
+  metrics:
+  - wis
+  - ae_median
+  disaggregate_by:
+  - location
+eval_sets:
+- eval_set_name: Full season
+  round_filters:
+    min: '2023-01-21'

--- a/tests/testthat/testdata/test_configs/config_valid_initial_sort_column.yaml
+++ b/tests/testthat/testdata/test_configs/config_valid_initial_sort_column.yaml
@@ -1,0 +1,14 @@
+schema_version: https://raw.githubusercontent.com/hubverse-org/hubPredEvalsData/main/inst/schema/v1.1.0/config_schema.json
+rounds_idx: 0
+initial_sort_column: wis
+targets:
+- target_id: wk inc flu hosp
+  metrics:
+  - wis
+  - ae_median
+  disaggregate_by:
+  - location
+eval_sets:
+- eval_set_name: Full season
+  round_filters:
+    min: '2023-01-21'

--- a/tests/testthat/testdata/test_configs/config_valid_initial_sort_column_cross_target.yaml
+++ b/tests/testthat/testdata/test_configs/config_valid_initial_sort_column_cross_target.yaml
@@ -1,0 +1,16 @@
+schema_version: https://raw.githubusercontent.com/hubverse-org/hubPredEvalsData/main/inst/schema/v1.1.0/config_schema.json
+rounds_idx: 0
+initial_sort_column: ae_median
+targets:
+- target_id: wk inc flu hosp
+  metrics:
+  - wis
+  - ae_median
+- target_id: wk flu hosp rate category
+  metrics:
+  - log_score
+  - rps
+eval_sets:
+- eval_set_name: Full season
+  round_filters:
+    min: '2023-01-21'

--- a/tests/testthat/testdata/test_configs/config_valid_initial_sort_column_disaggregate_by.yaml
+++ b/tests/testthat/testdata/test_configs/config_valid_initial_sort_column_disaggregate_by.yaml
@@ -1,0 +1,14 @@
+schema_version: https://raw.githubusercontent.com/hubverse-org/hubPredEvalsData/main/inst/schema/v1.1.0/config_schema.json
+rounds_idx: 0
+initial_sort_column: location
+targets:
+- target_id: wk inc flu hosp
+  metrics:
+  - wis
+  - ae_median
+  disaggregate_by:
+  - location
+eval_sets:
+- eval_set_name: Full season
+  round_filters:
+    min: '2023-01-21'

--- a/tests/testthat/testdata/test_configs/config_valid_initial_sort_column_scaled_rel.yaml
+++ b/tests/testthat/testdata/test_configs/config_valid_initial_sort_column_scaled_rel.yaml
@@ -1,0 +1,17 @@
+schema_version: https://raw.githubusercontent.com/hubverse-org/hubPredEvalsData/main/inst/schema/v1.1.0/config_schema.json
+rounds_idx: 0
+initial_sort_column: wis_scaled_relative_skill
+targets:
+- target_id: wk inc flu hosp
+  metrics:
+  - wis
+  - ae_median
+  relative_metrics:
+  - wis
+  baseline: FS-base
+  disaggregate_by:
+  - location
+eval_sets:
+- eval_set_name: Full season
+  round_filters:
+    min: '2023-01-21'


### PR DESCRIPTION
Implements https://github.com/hubverse-org/predevals/issues/4 : Adds an optional `initial_sort_column` field to the v1.1.0 config schema and validates that its value, when provided, is one of the columns present in the output scores table (model_id, n, target metrics, relative skill metrics, or disaggregate_by columns). Includes tests for valid and invalid values. Ran locally on metrocast dashboard to test integration with https://github.com/hubverse-org/predevals/pull/64 .

@annakrystalli : I see there are merge conflicts. Sorry if that's on me!

A note from Claude - @annakrystalli and @nickreich ? :
> **One gap to be aware of**: the `transform` config (v1.1.0) has an `append` option that, per its schema description, would produce additional transformed-scale columns alongside the natural-scale ones (e.g. `wis_log_shift`). That column-naming logic doesn't exist yet in `generate_eval_data.R` — `score_model_out` is called without any transform argument — so there's nothing to be inconsistent with today. When transform application is implemented, `validate_config_initial_sort_column` will need updating to include those derived column names.