### PR TITLE
Release hubPredEvalsData 1.1.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,10 @@
 Package: hubPredEvalsData
 Title: Data Creation for Hub Prediction Evaluations via predevals
-Version: 1.0.0.9000
+Version: 1.1.0
 Authors@R: c(
-    person("Evan", "Ray", , "elray@umass.edu", role = c("aut", "cre"))
+    person("Evan", "Ray", , "elray@umass.edu", role = "aut"),
+    person("Anna", "Krystalli", , "annakrystalli@googlemail.com", role = c("aut", "cre"),
+           comment = c(ORCID = "0000-0002-2378-4915"))
     )
 Description: This package generates data objects with scores for predictions in
     a hub, to be displayed on a dashboard using predevals.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# hubPredEvalsData (development version)
+# hubPredEvalsData 1.1.0
 
 ## New Features
 


### PR DESCRIPTION
Release of hubPredEvalsData **1.1.0** (minor bump from 1.0.0).

## New Features

- Optional scale-transformation support in `predevals-config.yml` via schema `v1.1.0` (`transform_defaults`, per-target `transform`; functions `log_shift`, `sqrt`, `log1p`, `log`, `log10`, `log2`) (#39), applied during scoring (#40).
- `scores.csv` now emitted in wide format with transformed-scale metrics as `<metric>__<label>` columns; transform-invariant metrics (`interval_coverage_<n>`, `bias`) reported once on the natural scale (#63).
- Added `generate_predevals_options()` to assemble `predevals-options.json` for the predevals dashboard (#41, closes #4).
- `generate_eval_data()` now auto-discovers oracle output from `hub_path` via `hubData::connect_target_oracle_output()` when `oracle_output` is not supplied (default `NULL`); passing `oracle_output` explicitly still works and suppresses discovery (#51).

## Bug Fixes

- `generate_eval_data()` no longer fails on ordinal pmf targets requesting `rps`; ordinal level order is read from `tasks.json` and forwarded to scoring (#48).
- `read_predevals_config()` warns/errors appropriately for ordinal pmf metrics against pre-v4 tasks schemas (#48).

## Maintainer

- Adds Anna Krystalli as author and updates the package maintainer (cre) to Anna Krystalli.