### PR TITLE
Bump to development version 1.1.0.9000

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hubPredEvalsData
 Title: Data Creation for Hub Prediction Evaluations via predevals
-Version: 1.1.0
+Version: 1.1.0.9000
 Authors@R: c(
     person("Evan", "Ray", , "elray@umass.edu", role = "aut"),
     person("Anna", "Krystalli", , "annakrystalli@googlemail.com", role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# hubPredEvalsData (development version)
+
 # hubPredEvalsData 1.1.0
 
 ## New Features


### PR DESCRIPTION
Post-release bump to the development version following the 1.1.0 release.

- Sets `Version` to `1.1.0.9000`.
- Adds a new development heading to `NEWS.md`.