### PR TITLE
Bump to development version 1.1.1.9000

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hubPredEvalsData
 Title: Data Creation for Hub Prediction Evaluations via predevals
-Version: 1.1.1
+Version: 1.1.1.9000
 Authors@R: c(
     person("Evan", "Ray", , "elray@umass.edu", role = "aut"),
     person("Anna", "Krystalli", , "annakrystalli@googlemail.com", role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# hubPredEvalsData (development version)
+
 # hubPredEvalsData 1.1.1
 
 ## Bug Fixes


### PR DESCRIPTION
Routine post-release bump to the development version following the `v1.1.1` release (#71, fixes #70).

* `DESCRIPTION`: `1.1.1` -> `1.1.1.9000`
* `NEWS.md`: add `# hubPredEvalsData (development version)` heading

🤖 Generated with [Claude Code](https://claude.com/claude-code)