### PR TITLE
Arrange scores rows before writing so scores.csv is deterministic (#25)

### DIFF
--- a/R/generate_eval_data.R
+++ b/R/generate_eval_data.R
@@ -183,6 +183,12 @@ get_and_save_scores <- function(
     dplyr::summarize(n = dplyr::n())
   scores <- scores |> dplyr::left_join(n_tasks_by_group, by = group_cols)
 
+  # The row order coming out of scoring reflects arrow's parallel, scan-order
+  # collect in load_model_out_in_eval_set(), so two runs on identical data emit
+  # the same rows shuffled. Sort on the (model_id, by) key, which is unique per
+  # row, so scores.csv is byte-stable across runs and diffable. See #25.
+  scores <- dplyr::arrange(scores, dplyr::across(dplyr::all_of(group_cols)))
+
   # Save the scores to a .csv file
   target_set_by_out_path <- file.path(out_path, target_id, eval_set_name)
   if (!is.null(by)) {

--- a/tests/testthat/test-generate_eval_data.R
+++ b/tests/testthat/test-generate_eval_data.R
@@ -631,3 +631,59 @@ test_that("a (model, by) cell present only on a non-anchor output type survives 
   expect_true(is.na(us_psi$se_point))
   expect_true(is.finite(us_psi$wis))
 })
+
+
+test_that("scores.csv row order is deterministic regardless of input row order (#25)", {
+  # arrow's parallel collect in load_model_out_in_eval_set() returns rows in a
+  # nondeterministic order and hubEvals::score_model_out() carries that order
+  # into its output, so two runs on identical data used to emit the same rows
+  # shuffled. get_and_save_scores() now arranges on the (model_id, by) key
+  # before writing. Feeding deliberately reverse-ordered input must still yield
+  # output in that canonical order, for both the overall (key model_id only)
+  # and disaggregated (key model_id + by) paths.
+  hub_path <- test_path("testdata", "ecfh")
+  target_id <- "wk inc flu hosp"
+  task_groups_w_target <- get_task_groups_w_target(hub_path, target_id, 0)
+  metric_name_to_output_type <- get_metric_name_to_output_type(
+    task_groups_w_target,
+    "wis"
+  )
+  oracle_output <- hubData::connect_target_oracle_output(hub_path) |>
+    dplyr::collect()
+  reversed_input <- hubData::connect_hub(hub_path) |>
+    dplyr::collect() |>
+    dplyr::filter(target == target_id)
+  # There is no error or warning if the arrange is dropped; the test can only
+  # catch that by comparing row order. But scoring might return rows already in
+  # canonical order by chance, in which case the output would pass even without
+  # the arrange. Reversing the input first guarantees that a dropped arrange
+  # yields reverse-ordered (non-canonical) output, so the assertion fails.
+  reversed_input <- reversed_input[rev(seq_len(nrow(reversed_input))), ]
+
+  for (by in list(NULL, "location")) {
+    out_path <- withr::local_tempdir()
+    get_and_save_scores(
+      model_out_tbl = reversed_input,
+      oracle_output = oracle_output,
+      metric_name_to_output_type = metric_name_to_output_type,
+      relative_metrics = NULL,
+      baseline = NULL,
+      target_id = target_id,
+      eval_set_name = "set",
+      by = by,
+      out_path = out_path,
+      transform = NULL,
+      task_groups_w_target = task_groups_w_target
+    )
+    score_dir <- file.path(out_path, target_id, "set")
+    if (!is.null(by)) {
+      score_dir <- file.path(score_dir, by)
+    }
+    scores <- read.csv(file.path(score_dir, "scores.csv"))
+    expect_equal(
+      scores,
+      dplyr::arrange(scores, dplyr::across(dplyr::all_of(c("model_id", by)))),
+      info = paste("by =", deparse(by))
+    )
+  }
+})


### PR DESCRIPTION
Closes #25.

`get_and_save_scores()` wrote scores in whatever row order came out of scoring. That order reflects arrow's parallel, scan-order-dependent collect in `load_model_out_in_eval_set()`, and `hubEvals::score_model_out()` carries its input row order into its output, so two runs on identical data emitted the same rows shuffled. As @zkamvar noted, that means the files cannot be diffed or md5-compared to confirm a no-change situation.

The fix sorts on the `(model_id, by)` key, which is unique per row, immediately before `utils::write.csv()`, so `scores.csv` is byte-stable across runs regardless of arrow's scan order.

### Tests
A new test feeds deliberately reverse-ordered input through `get_and_save_scores()` and asserts the written rows equal their own canonical `(model_id, by)` sort, for both the overall (`by = NULL`, sorts on `model_id` only) and disaggregated (`by = "location"`) paths. It fails on both paths without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)