### PR TITLE
Release hubPredEvalsData 1.2.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hubPredEvalsData
 Title: Data Creation for Hub Prediction Evaluations via predevals
-Version: 1.1.1.9000
+Version: 1.2.0
 Authors@R: c(
     person("Evan", "Ray", , "elray@umass.edu", role = "aut"),
     person("Anna", "Krystalli", , "annakrystalli@googlemail.com", role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,13 @@
-# hubPredEvalsData (development version)
+# hubPredEvalsData 1.2.0
 
 ## New Features
 
 * `generate_predevals_options()` now pulls `target_name` and `target_units` from the hub's `tasks.json` `target_metadata` into each `targets` entry, just after `target_id`. The dashboard uses `target_name` to label target menu items; `target_units` is passed through for future labelling of unit-valued scores (#21).
+* `scores.csv` rows are now sorted on the `(model_id, by)` key immediately before writing, so the file is byte-stable across runs regardless of arrow's scan order. Scores are unchanged; the deterministic order means outputs can be diffed or md5-compared to confirm a no-change situation (#25).
+
+## Bug Fixes
+
+* `get_and_save_scores()` now merges the per-output-type score frames with a `full_join` instead of a `left_join` anchored on the first output type. Previously any model, or any `(model_id, by)` cell, scored only on a later output type was silently dropped, and which models survived depended on the arbitrary order metrics were listed in the config (#75).
 
 # hubPredEvalsData 1.1.1
 


### PR DESCRIPTION
Release of hubPredEvalsData v1.2.0.

## New Features

* `generate_predevals_options()` now pulls `target_name` and `target_units` from the hub's `tasks.json` `target_metadata` into each `targets` entry (#21).
* `scores.csv` rows are now sorted on the `(model_id, by)` key before writing, so the file is byte-stable across runs and can be diffed or md5-compared to confirm a no-change situation (#25).

## Bug Fixes

* `get_and_save_scores()` now merges per-output-type score frames with a `full_join` instead of a `left_join`, so models scored only on a later output type are no longer silently dropped (#75).