### PR TITLE
Add benchmark for eval data generation

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -14,3 +14,4 @@
 ^pkgdown$
 ^[.]?air[.]toml$
 ^\.vscode$
+^_benchmark$

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 docs
 .attic/
 .claude/settings.local.json
+_benchmark/Rprof.out
+_benchmark/*.log

--- a/_benchmark/README.md
+++ b/_benchmark/README.md
@@ -1,0 +1,108 @@
+# Benchmark
+
+A repeatable measurement of `generate_eval_data()` for the performance work in
+[#80](https://github.com/hubverse-org/hubPredEvalsData/issues/80), so
+optimisations are measured rather than assumed.
+
+Not part of the package: `_benchmark/` is `.Rbuildignore`d.
+
+## Running it
+
+Needs a local clone of
+[`cdcepi/FluSight-forecast-hub`](https://github.com/cdcepi/FluSight-forecast-hub):
+
+```sh
+HUBPREDEVALS_BENCHMARK_HUB=/path/to/FluSight-forecast-hub \
+  Rscript _benchmark/run-benchmark.R
+```
+
+The package is loaded with `pkgload::load_all()`, so it measures the working
+tree, not the installed version.
+
+For true peak RSS, which is what decides whether a change fits the runner's
+memory, wrap it:
+
+```sh
+HUBPREDEVALS_BENCHMARK_HUB=... /usr/bin/time -l Rscript _benchmark/run-benchmark.R
+```
+
+## Benchmarking a dependency
+
+Most of the runtime is in the dependencies, not this package: scoring and
+relative skill live in `hubEvals`, and the pairwise-comparison merging under
+that in `scoringutils`. To measure a change in either, point these at a local
+checkout and they are loaded in dependency order, so a dev `scoringutils` runs
+under a dev `hubEvals` under this package's working tree:
+
+```sh
+HUBPREDEVALS_BENCHMARK_HUB=... \
+  HUBPREDEVALS_BENCHMARK_HUBEVALS=/path/to/hubEvals \
+  HUBPREDEVALS_BENCHMARK_SCORINGUTILS=/path/to/scoringutils \
+  Rscript _benchmark/run-benchmark.R
+```
+
+Unset, each dependency is taken from the installed library.
+
+## Labelling runs
+
+Each run records what it measured, so `results.csv` rows stay interpretable:
+
+- `label` — the run's name. Set `HUBPREDEVALS_BENCHMARK_LABEL` to name it after
+  the change under test (e.g. `p3-test-type-null`); defaults to this package's
+  git id.
+- `hubevals`, `scoringutils` — each dependency's git id.
+
+A git id is `branch@sha`, suffixed `-dirty` when the working tree has
+uncommitted changes. Since `load_all` measures the working tree, the `-dirty`
+marker is what flags a run that a sha alone can't reproduce, so name such runs
+via `HUBPREDEVALS_BENCHMARK_LABEL`. An installed dependency records
+`version@sha` (from the sha pak/remotes bakes into `DESCRIPTION`), or just the
+version for a plain install that carries no sha.
+
+`results.csv` is committed as a record of baselines. Numbers are only comparable
+within a machine, so the `sysname` / `machine` / `r_version` columns tell runs
+apart.
+
+`Rprof.out` (the raw profile, ~18 MB) and any `*.log` are regenerated on every
+run and are git-ignored.
+
+## Where the time goes
+
+`results.csv` is the per-run numbers; [`prof-summary.md`](prof-summary.md) is the
+curated record of *where* the time goes and how that shape shifts as the work in
+#80 lands. Each run prints its own `Rprof` breakdown, so add to `prof-summary.md`
+only when a run moves a cost, removes one, or surfaces a new hotspot, not for
+every run.
+
+## The config
+
+`predevals-config.yml` is derived from the live FluSight dashboard config
+([`reichlab/flusight-dashboard`](https://github.com/reichlab/flusight-dashboard/blob/main/predevals-config.yml)),
+trimmed so a run takes minutes rather than the ~1.5 h a full build needs.
+
+The hub's model-output is left alone: its volume (1.5 GB, 95 models, ~4118
+files) is what makes this a realistic test. Only the config is cut, since those
+axes multiply the work without changing where the time goes:
+
+- **one target** (`wk inc flu hosp`) rather than two;
+- **two metrics** (`wis`, `interval_coverage_95`) plus one relative metric
+  (`wis`), keeping one quantile and one coverage metric;
+- **three eval_sets** rather than twelve: two 2024-2025 season sets (state and
+  national) and one `n_last` set, so the over-read described in P5 stays
+  measurable.
+
+All four `disaggregate_by` variables are kept deliberately. The per-`by` loop is
+what P2 targets, so cutting it would hide the redundancy the benchmark exists to
+measure.
+
+Being a fixed file matters: baselines are only comparable if the config doesn't
+move. Regenerating it from upstream would drift as the dashboard gains seasons.
+
+## What it reports
+
+- **wall-clock**;
+- **R heap peak**, from `gc()` max-used counters;
+- **Arrow pool peak**, tracked separately because Arrow allocates off the R heap
+  and so is invisible to `gc()`;
+- a **profile** of where time went, from `Rprof`, filtered to entries taking at
+  least 1% of total time. This is what gives the load vs score vs write split.

--- a/_benchmark/predevals-config.yml
+++ b/_benchmark/predevals-config.yml
@@ -1,0 +1,259 @@
+schema_version: https://raw.githubusercontent.com/hubverse-org/hubPredEvalsData/main/inst/schema/v1.0.1/config_schema.json
+rounds_idx: 0
+targets:
+- target_id: wk inc flu hosp
+  metrics:
+  - wis
+  - interval_coverage_95
+  relative_metrics: wis
+  baseline: FluSight-baseline
+  disaggregate_by:
+  - location
+  - reference_date
+  - horizon
+  - target_end_date
+eval_sets:
+- eval_set_name: 2024-2025 season, state level
+  task_filters:
+    location:
+    - '01'
+    - '02'
+    - '04'
+    - '05'
+    - '06'
+    - 08
+    - 09
+    - '10'
+    - '11'
+    - '12'
+    - '13'
+    - '15'
+    - '16'
+    - '17'
+    - '18'
+    - '19'
+    - '20'
+    - '21'
+    - '22'
+    - '23'
+    - '24'
+    - '25'
+    - '26'
+    - '27'
+    - '28'
+    - '29'
+    - '30'
+    - '31'
+    - '32'
+    - '33'
+    - '34'
+    - '35'
+    - '36'
+    - '37'
+    - '38'
+    - '39'
+    - '40'
+    - '41'
+    - '42'
+    - '44'
+    - '45'
+    - '46'
+    - '47'
+    - '48'
+    - '49'
+    - '50'
+    - '51'
+    - '53'
+    - '54'
+    - '55'
+    - '56'
+    horizon:
+    - 0
+    - 1
+    - 2
+    - 3
+    reference_date:
+    - '2024-11-30'
+    - '2024-12-07'
+    - '2024-12-14'
+    - '2024-12-21'
+    - '2024-12-28'
+    - '2025-01-04'
+    - '2025-01-11'
+    - '2025-01-18'
+    - '2025-02-01'
+    - '2025-02-08'
+    - '2025-02-15'
+    - '2025-02-22'
+    - '2025-03-01'
+    - '2025-03-08'
+    - '2025-03-15'
+    - '2025-03-22'
+    - '2025-03-29'
+    - '2025-04-05'
+    - '2025-04-12'
+    - '2025-04-19'
+    - '2025-04-26'
+    - '2025-05-03'
+    - '2025-05-10'
+    - '2025-05-17'
+    - '2025-05-24'
+    - '2025-05-31'
+- eval_set_name: 2024-2025 season, US national level
+  task_filters:
+    location: US
+    horizon:
+    - 0
+    - 1
+    - 2
+    - 3
+    reference_date:
+    - '2024-11-30'
+    - '2024-12-07'
+    - '2024-12-14'
+    - '2024-12-21'
+    - '2024-12-28'
+    - '2025-01-04'
+    - '2025-01-11'
+    - '2025-01-18'
+    - '2025-02-01'
+    - '2025-02-08'
+    - '2025-02-15'
+    - '2025-02-22'
+    - '2025-03-01'
+    - '2025-03-08'
+    - '2025-03-15'
+    - '2025-03-22'
+    - '2025-03-29'
+    - '2025-04-05'
+    - '2025-04-12'
+    - '2025-04-19'
+    - '2025-04-26'
+    - '2025-05-03'
+    - '2025-05-10'
+    - '2025-05-17'
+    - '2025-05-24'
+    - '2025-05-31'
+- eval_set_name: Last 4 weeks, state level
+  round_filters:
+    min: '2024-11-30'
+    n_last: 5
+  task_filters:
+    location:
+    - '01'
+    - '02'
+    - '04'
+    - '05'
+    - '06'
+    - 08
+    - 09
+    - '10'
+    - '11'
+    - '12'
+    - '13'
+    - '15'
+    - '16'
+    - '17'
+    - '18'
+    - '19'
+    - '20'
+    - '21'
+    - '22'
+    - '23'
+    - '24'
+    - '25'
+    - '26'
+    - '27'
+    - '28'
+    - '29'
+    - '30'
+    - '31'
+    - '32'
+    - '33'
+    - '34'
+    - '35'
+    - '36'
+    - '37'
+    - '38'
+    - '39'
+    - '40'
+    - '41'
+    - '42'
+    - '44'
+    - '45'
+    - '46'
+    - '47'
+    - '48'
+    - '49'
+    - '50'
+    - '51'
+    - '53'
+    - '54'
+    - '55'
+    - '56'
+    - '72'
+    horizon:
+    - 0
+    - 1
+    - 2
+    - 3
+task_id_text:
+  location:
+    US: United States
+    '01': Alabama
+    '02': Alaska
+    '04': Arizona
+    '05': Arkansas
+    '06': California
+    08: Colorado
+    09: Connecticut
+    '10': Delaware
+    '11': District of Columbia
+    '12': Florida
+    '13': Georgia
+    '15': Hawaii
+    '16': Idaho
+    '17': Illinois
+    '18': Indiana
+    '19': Iowa
+    '20': Kansas
+    '21': Kentucky
+    '22': Louisiana
+    '23': Maine
+    '24': Maryland
+    '25': Massachusetts
+    '26': Michigan
+    '27': Minnesota
+    '28': Mississippi
+    '29': Missouri
+    '30': Montana
+    '31': Nebraska
+    '32': Nevada
+    '33': New Hampshire
+    '34': New Jersey
+    '35': New Mexico
+    '36': New York
+    '37': North Carolina
+    '38': North Dakota
+    '39': Ohio
+    '40': Oklahoma
+    '41': Oregon
+    '42': Pennsylvania
+    '44': Rhode Island
+    '45': South Carolina
+    '46': South Dakota
+    '47': Tennessee
+    '48': Texas
+    '49': Utah
+    '50': Vermont
+    '51': Virginia
+    '53': Washington
+    '54': West Virginia
+    '55': Wisconsin
+    '56': Wyoming
+    '60': American Samoa
+    '66': Guam
+    '69': Northern Mariana Islands
+    '72': Puerto Rico
+    '74': U.S. Minor Outlying Islands
+    '78': Virgin Islands

--- a/_benchmark/prof-summary.md
+++ b/_benchmark/prof-summary.md
@@ -1,0 +1,37 @@
+# Profile summary
+
+Where the benchmark run spends its time, and how that shifts as the
+optimisation work in [#80](https://github.com/hubverse-org/hubPredEvalsData/issues/80)
+lands.
+
+`results.csv` records the numbers for every run; this file is curated. Add an
+entry only when a run meaningfully changes the *shape* of the profile (a cost
+moves, disappears, or a new hotspot surfaces), not for every run. Each run
+prints its own `Rprof` breakdown, so this is the place to record the ones worth
+remembering.
+
+## Baseline — `a6257af`, hubEvals 0.3.0.9000, scoringutils 2.2.0
+
+647 s wall-clock, peak RSS 6.85 GB.
+
+| | total | % |
+|---|---|---|
+| Relative skill (`get_pairwise_comparisons`) | 427.5 s | 62.2% |
+| ├─ of which `wilcox.test` | 16.4 s | 2.4% |
+| `score()` | 167.5 s | 24.4% |
+| Load (`load_model_out_in_eval_set`, all calls) | 32.5 s | 4.7% |
+| ├─ of which `collect()` | 22.3 s | 3.2% |
+| ├─ of which `connect_hub()` | 3.0 s | 0.4% |
+| Write | 0.04 s | ~0% |
+
+Dominant cost is the pairwise comparisons in relative skill, and within them the
+merging, not the statistics: `forderv` (data.table ordering, inside
+`merge.data.table`, inside `compare_forecasts`) is 43.8% of total self-time on
+its own. `wilcox.test` is only 2.4%.
+
+Load is a small fraction, and the collect is already projected to the 9 columns
+scoring needs. The write is negligible.
+
+Consequences for the #80 plan are in the issue comments: the merge cost
+(hubverse-org/hubEvals#144) is the real prize, P2 (#83) next, load-side work
+(#82) is minor.

--- a/_benchmark/results.csv
+++ b/_benchmark/results.csv
@@ -1,0 +1,2 @@
+"label","hubevals","scoringutils","elapsed_s","r_peak_mb","arrow_peak_mb","sysname","machine","r_version"
+"ak/benchmark-eval-data-generation/81@a6257af","0.3.0.9000","2.2.0",647.2,3891,1156,"Darwin","arm64","4.5.2"

--- a/_benchmark/run-benchmark.R
+++ b/_benchmark/run-benchmark.R
@@ -1,0 +1,162 @@
+# Run generate_eval_data() against the FluSight hub with the trimmed benchmark
+# config, and report wall-clock, memory and a load/score/write split.
+#
+# Usage:
+#   HUBPREDEVALS_BENCHMARK_HUB=/path/to/FluSight-forecast-hub \
+#     Rscript _benchmark/run-benchmark.R
+#
+# For true peak RSS (the number that decides whether a change fits the runner's
+# memory), wrap the call:
+#   /usr/bin/time -l Rscript _benchmark/run-benchmark.R
+
+benchmark_dir <- dirname(
+  sub("^--file=", "", grep("^--file=", commandArgs(), value = TRUE))
+)
+pkg_dir <- dirname(benchmark_dir)
+
+hub_path <- Sys.getenv("HUBPREDEVALS_BENCHMARK_HUB")
+if (hub_path == "") {
+  stop(
+    "Set HUBPREDEVALS_BENCHMARK_HUB to a local FluSight-forecast-hub clone.",
+    call. = FALSE
+  )
+}
+if (!dir.exists(file.path(hub_path, "model-output"))) {
+  stop("No model-output/ under ", hub_path, call. = FALSE)
+}
+
+config_path <- file.path(benchmark_dir, "predevals-config.yml")
+
+# A checkout's git id: branch@sha, with -dirty when the working tree has
+# uncommitted changes. The dirty marker is the honest signal that a run isn't
+# reproducible from the sha alone, which is the load_all-uncommitted case.
+git_id <- function(dir) {
+  branch <- system2(
+    "git",
+    c("-C", dir, "rev-parse", "--abbrev-ref", "HEAD"),
+    stdout = TRUE
+  )
+  sha <- system2(
+    "git",
+    c("-C", dir, "rev-parse", "--short", "HEAD"),
+    stdout = TRUE
+  )
+  dirty <- length(system2(
+    "git",
+    c("-C", dir, "status", "--porcelain"),
+    stdout = TRUE
+  )) >
+    0
+  paste0(branch, "@", sha, if (dirty) "-dirty" else "")
+}
+
+# Human-readable run label: name a run after the change under test. Defaults to
+# this package's git id.
+label <- Sys.getenv("HUBPREDEVALS_BENCHMARK_LABEL")
+if (label == "") {
+  label <- git_id(pkg_dir)
+}
+
+# Most of the runtime lives in the dependencies, not this package: hubEvals
+# (P2/P3) and scoringutils (pairwise-comparison merging, hubEvals#144). To
+# benchmark a change in either, point these env vars at a local checkout of it;
+# unset, the installed version is used. Loading in dependency order means a dev
+# scoringutils runs under a dev hubEvals under this package's working tree.
+load_dev_dep <- function(env_var) {
+  src <- Sys.getenv(env_var)
+  if (src == "") {
+    return(NULL)
+  }
+  if (!dir.exists(src)) {
+    stop(env_var, " set but not a directory: ", src, call. = FALSE)
+  }
+  pkgload::load_all(src, quiet = TRUE)
+  src
+}
+scoringutils_src <- load_dev_dep("HUBPREDEVALS_BENCHMARK_SCORINGUTILS")
+hubevals_src <- load_dev_dep("HUBPREDEVALS_BENCHMARK_HUBEVALS")
+
+pkgload::load_all(pkg_dir, quiet = TRUE)
+
+# Record what was measured for each dependency: a dev checkout as its git id
+# (branch@sha[-dirty]); an installed package as version@sha from the RemoteSha
+# pak/remotes bakes into DESCRIPTION, degrading to the bare version only for a
+# plain install that carries no sha.
+dep_id <- function(pkg, src) {
+  if (!is.null(src)) {
+    return(git_id(src))
+  }
+  version <- as.character(utils::packageVersion(pkg))
+  sha <- utils::packageDescription(pkg)$RemoteSha
+  # RemoteSha may hold a tag/ref ("2.2.0") rather than a commit; only append a
+  # real hex sha, otherwise the version string already says it all.
+  if (is.null(sha) || is.na(sha) || !grepl("^[0-9a-f]{7,40}$", sha)) {
+    version
+  } else {
+    paste0(version, "@", substr(sha, 1, 7))
+  }
+}
+hubevals_id <- dep_id("hubEvals", hubevals_src)
+scoringutils_id <- dep_id("scoringutils", scoringutils_src)
+
+out_path <- file.path(tempdir(), "benchmark-out")
+dir.create(out_path, showWarnings = FALSE)
+prof_path <- file.path(benchmark_dir, "Rprof.out")
+
+# Baselines to measure against. gc(reset = TRUE) resets the max-used counters;
+# the Arrow pool is tracked separately because Arrow allocates off the R heap
+# and so is invisible to gc().
+invisible(gc(reset = TRUE))
+invisible(arrow::default_memory_pool()$max_memory) # touch pool before timing
+
+cat("hub:          ", hub_path, "\n")
+cat("config:       ", config_path, "\n")
+cat("label:        ", label, "\n")
+cat("hubEvals:     ", hubevals_id, "\n")
+cat("scoringutils: ", scoringutils_id, "\n\n")
+
+Rprof(prof_path, interval = 0.02, memory.profiling = FALSE)
+elapsed <- system.time(
+  generate_eval_data(
+    hub_path = hub_path,
+    config_path = config_path,
+    out_path = out_path
+  )
+)
+Rprof(NULL)
+
+gc_result <- gc()
+r_peak_mb <- sum(gc_result[, "max used"] * c(56, 8)) / 1024^2
+arrow_peak_mb <- arrow::default_memory_pool()$max_memory / 1024^2
+
+cat("\n=== ", label, " ===\n")
+cat("wall-clock (s):   ", round(elapsed[["elapsed"]], 1), "\n")
+cat("R heap peak (MB): ", round(r_peak_mb), "\n")
+cat("Arrow peak (MB):  ", round(arrow_peak_mb), "\n")
+
+prof <- summaryRprof(prof_path)$by.total
+prof <- prof[prof$total.pct >= 1, c("total.time", "total.pct", "self.pct")]
+cat("\n=== profile (>=1% of total time) ===\n")
+print(utils::head(prof, 40))
+
+results_path <- file.path(benchmark_dir, "results.csv")
+result_row <- data.frame(
+  label = label,
+  hubevals = hubevals_id,
+  scoringutils = scoringutils_id,
+  elapsed_s = round(elapsed[["elapsed"]], 1),
+  r_peak_mb = round(r_peak_mb),
+  arrow_peak_mb = round(arrow_peak_mb),
+  sysname = Sys.info()[["sysname"]],
+  machine = Sys.info()[["machine"]],
+  r_version = paste0(R.version$major, ".", R.version$minor)
+)
+write.table(
+  result_row,
+  results_path,
+  sep = ",",
+  row.names = FALSE,
+  col.names = !file.exists(results_path),
+  append = file.exists(results_path)
+)
+cat("\nAppended to", results_path, "\n")


### PR DESCRIPTION
Resolves #81.

Adds a `_benchmark/` folder that measures `generate_eval_data()` on the FluSight
hub, so the performance work in #80 is driven by numbers rather than by reading
source.

- `predevals-config.yml` — the live FluSight dashboard config trimmed to one
  target, three eval_sets and a reduced metric set, so a run takes ~10 min
  rather than the ~1.5 h a full build needs. The hub's model-output is left at
  full volume, since that is what makes the test realistic.
- `run-benchmark.R` — loads the working tree with `pkgload::load_all()` and
  reports wall-clock, R heap peak, Arrow pool peak and an `Rprof` time split.
  Most of the runtime is in the dependencies, so `hubEvals` and `scoringutils`
  can each be pointed at a local checkout and are recorded per run.
- `results.csv` — a committed record of baselines.

The baseline is posted on #81; in short, loading is ~5% of the run and the
relative-skill pairwise comparisons are ~62%, which reorders the priorities in
#80.

The folder is committed but `.Rbuildignore`d, so it ships with the source for
transparency while the optimisation work is live but is excluded from the built
package. Straightforward to remove once the work concludes if we'd rather it not
live here long-term.
