### PR TITLE
Fix `n` to count only scored forecasts (#19)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ Imports:
     cli,
     dplyr (>= 1.1.0),
     hubData,
-    hubEvals (>= 0.3.1.9000),
+    hubEvals (>= 0.4.0),
     hubUtils,
     jsonlite,
     jsonvalidate,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ Imports:
     cli,
     dplyr (>= 1.1.0),
     hubData,
-    hubEvals,
+    hubEvals (>= 0.3.1.9000),
     hubUtils,
     jsonlite,
     jsonvalidate,

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,4 +2,5 @@
 
 export(generate_eval_data)
 export(generate_predevals_options)
+importFrom(hubEvals,score_model_out)
 importFrom(rlang,"%||%")

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # hubPredEvalsData (development version)
 
+## Bug Fixes
+
+* The number of predictions scored (`n`) in `scores.csv` now counts only forecasts that had a corresponding observation to score against, rather than every submitted prediction, correcting an overcount wherever a model submitted predictions for units with no observation. In the rare case where this count differs across a target's output types, `scores.csv` reports a separate `n_<output_type>` column per output type in place of the single `n` (#19).
+
 # hubPredEvalsData 1.2.0
 
 ## New Features

--- a/R/generate_eval_data.R
+++ b/R/generate_eval_data.R
@@ -169,19 +169,12 @@ get_and_save_scores <- function(
     # (anchor-present model lacking a later type) already produced. See #75.
     purrr::reduce(dplyr::full_join, by = c("model_id", by))
 
-  # Add the number of prediction tasks that were scored within each model/by group
-  # After dropping output_type, output_type_id, and value, we are left with model_id
-  # and task id columns.  The number of prediction tasks is the number of distinct
-  # rows within each group.
+  scores <- collapse_output_type_n(
+    scores,
+    unique(metric_name_to_output_type$output_type)
+  )
+
   group_cols <- c("model_id", by)
-  n_tasks_by_group <- model_out_tbl |>
-    dplyr::select(
-      !dplyr::all_of(c("output_type", "output_type_id", "value"))
-    ) |>
-    dplyr::group_by(dplyr::across(dplyr::all_of(group_cols))) |>
-    dplyr::distinct() |>
-    dplyr::summarize(n = dplyr::n())
-  scores <- scores |> dplyr::left_join(n_tasks_by_group, by = group_cols)
 
   # The row order coming out of scoring reflects arrow's parallel, scan-order
   # collect in load_model_out_in_eval_set(), so two runs on identical data emit
@@ -205,6 +198,36 @@ get_and_save_scores <- function(
 }
 
 
+#' Collapse the per-output-type scored counts into a single `n` column.
+#'
+#' Each output type contributes its scored-forecast count as an `n_<output_type>`
+#' column (from `score_model_out(include_count = TRUE)`), sitting just after that
+#' type's metric columns. Where the counts never disagree they are replaced by a
+#' single `n`: a row's counts disagree only when its non-NA values span more than
+#' one number (per-row max and min differ), so a row on which just one output
+#' type contributed a count (NA elsewhere, e.g. a model that submitted a single
+#' type) keeps that lone value. If any row carries two differing counts the
+#' output types genuinely diverge for this target and the per-output-type columns
+#' are left as-is. See #19.
+#'
+#' @param scores The merged wide-format scores, one row per `(model_id, by)`.
+#' @param output_types The output types scored for this target, used to locate
+#'   the `n_<output_type>` columns.
+#' @return `scores` with the count columns collapsed to a single `n`, or
+#'   unchanged when the counts diverge.
+#' @noRd
+collapse_output_type_n <- function(scores, output_types) {
+  n_cols <- intersect(paste0("n_", output_types), names(scores))
+  row_max <- do.call(pmax, c(scores[n_cols], na.rm = TRUE))
+  row_min <- do.call(pmin, c(scores[n_cols], na.rm = TRUE))
+  if (all(row_max == row_min, na.rm = TRUE)) {
+    scores[n_cols] <- NULL
+    scores[["n"]] <- row_max
+  }
+  scores
+}
+
+
 #' Get scores for a target in a given evaluation set for a specific output type.
 #'
 #' If `transform` is set and the output type is transformable
@@ -213,6 +236,9 @@ get_and_save_scores <- function(
 #' `scale` column when `append = TRUE`) is pivoted to wide format here so that
 #' transformed-scale metrics become label-prefixed columns alongside their
 #' natural-scale counterparts.
+#'
+#' `score_model_out()` is imported, not called as `hubEvals::`, so tests can mock it.
+#' @importFrom hubEvals score_model_out
 #' @noRd
 get_scores_for_output_type <- function(
   model_out_tbl,
@@ -252,7 +278,12 @@ get_scores_for_output_type <- function(
     metrics = metrics,
     relative_metrics = relative_metrics,
     baseline = baseline,
-    by = score_by
+    by = score_by,
+    # Count the forecasts actually scored per group (after the oracle join drops
+    # units with no observation), rather than counting submitted predictions.
+    # hubEvals returns this as a `count` column; we carry it as `n_<output_type>`
+    # below and merge it back in get_and_save_scores(). See #19.
+    include_count = TRUE
   )
   # Ordinal pmf with a metric that requires ordinal dispatch (e.g. rps): pass
   # the ordered level vector so scoringutils dispatches as forecast_ordinal
@@ -274,7 +305,19 @@ get_scores_for_output_type <- function(
     score_args$transform_label <- transform_label
     score_args <- c(score_args, transform$args)
   }
-  scores <- do.call(hubEvals::score_model_out, score_args)
+  scores <- do.call(score_model_out, score_args)
+
+  # Set the scored-forecast count aside as `n_<output_type>` before the metric
+  # columns are reshaped below, then re-attach it as the final column so it ends
+  # up immediately after this output type's metrics once the per-output-type
+  # frames are merged. Under `transform_append = TRUE` scoring emits one row per
+  # scale with identical counts, so a distinct on the group + count collapses
+  # them to one row per group. See #19.
+  count_col <- paste0("n_", output_type)
+  group_cols <- c("model_id", by)
+  counts <- dplyr::distinct(scores[c(group_cols, "count")])
+  names(counts)[names(counts) == "count"] <- count_col
+  scores[["count"]] <- NULL
 
   scores <- order_relative_metric_cols(
     scores,
@@ -304,7 +347,7 @@ get_scores_for_output_type <- function(
     scores <- scores[c("model_id", by, ordered_metric_cols)]
   }
 
-  scores
+  dplyr::left_join(scores, counts, by = group_cols)
 }
 
 

--- a/R/generate_eval_data.R
+++ b/R/generate_eval_data.R
@@ -202,13 +202,16 @@ get_and_save_scores <- function(
 #'
 #' Each output type contributes its scored-forecast count as an `n_<output_type>`
 #' column (from `score_model_out(include_count = TRUE)`), sitting just after that
-#' type's metric columns. Where the counts never disagree they are replaced by a
-#' single `n`: a row's counts disagree only when its non-NA values span more than
-#' one number (per-row max and min differ), so a row on which just one output
-#' type contributed a count (NA elsewhere, e.g. a model that submitted a single
-#' type) keeps that lone value. If any row carries two differing counts the
-#' output types genuinely diverge for this target and the per-output-type columns
-#' are left as-is. See #19.
+#' type's metric columns.
+#'
+#' The counts collapse to a single `n` unless some row holds two counts that
+#' differ. Agreement is judged row by row, over non-NA values only (per-row max
+#' against per-row min). So a row where only one output type contributed a count
+#' keeps that lone value. An NA count means the model submitted nothing for that
+#' output type, which the row's NA metric columns already show.
+#'
+#' If any row does hold two differing counts, the output types genuinely diverge
+#' for this target and the per-output-type columns are left as-is. See #19.
 #'
 #' @param scores The merged wide-format scores, one row per `(model_id, by)`.
 #' @param output_types The output types scored for this target, used to locate

--- a/tests/testthat/test-generate_eval_data.R
+++ b/tests/testthat/test-generate_eval_data.R
@@ -687,3 +687,194 @@ test_that("scores.csv row order is deterministic regardless of input row order (
     )
   }
 })
+
+
+test_that("n counts only forecasts with a matching oracle observation (#19)", {
+  # The scored count must exclude submitted forecasts that had no oracle
+  # observation to be scored against. Dropping the observations for one location
+  # leaves those location's quantile forecasts unscored, so `n` must fall by
+  # exactly the number of forecast units in that location, not stay at the count
+  # of all submitted units (the pre-#19 behaviour).
+  hub_path <- test_path("testdata", "ecfh")
+  target_id <- "wk inc flu hosp"
+  task_groups_w_target <- get_task_groups_w_target(hub_path, target_id, 0)
+  metric_name_to_output_type <- get_metric_name_to_output_type(
+    task_groups_w_target,
+    "wis"
+  )
+  model_out_tbl <- hubData::connect_hub(hub_path) |>
+    dplyr::collect() |>
+    dplyr::filter(target == target_id)
+  oracle_output <- hubData::connect_target_oracle_output(hub_path) |>
+    dplyr::collect()
+
+  dropped_loc <- "US"
+  partial_oracle <- oracle_output |> dplyr::filter(location != dropped_loc)
+
+  # Independent expectation: one scored unit per distinct quantile forecast unit
+  # (task-id combination) that has an observation. The oracle is complete, so
+  # with the full oracle every submitted unit is scored; with the partial oracle
+  # the dropped location's units are not.
+  q_units <- model_out_tbl |>
+    dplyr::filter(output_type == "quantile") |>
+    dplyr::distinct(
+      model_id,
+      location,
+      reference_date,
+      horizon,
+      target_end_date
+    )
+  exp_full <- q_units |> dplyr::count(model_id, name = "n")
+  exp_partial <- q_units |>
+    dplyr::filter(location != dropped_loc) |>
+    dplyr::count(model_id, name = "n")
+
+  score_n <- function(oracle) {
+    out_path <- withr::local_tempdir()
+    get_and_save_scores(
+      model_out_tbl = model_out_tbl,
+      oracle_output = oracle,
+      metric_name_to_output_type = metric_name_to_output_type,
+      relative_metrics = NULL,
+      baseline = NULL,
+      target_id = target_id,
+      eval_set_name = "set",
+      by = NULL,
+      out_path = out_path,
+      transform = NULL,
+      task_groups_w_target = task_groups_w_target
+    )
+    read.csv(file.path(out_path, target_id, "set", "scores.csv"))[c(
+      "model_id",
+      "n"
+    )]
+  }
+
+  n_full <- score_n(oracle_output)
+  n_partial <- score_n(partial_oracle)
+
+  expect_equal(n_full, as.data.frame(exp_full), ignore_attr = TRUE)
+  expect_equal(n_partial, as.data.frame(exp_partial), ignore_attr = TRUE)
+  # And the fix actually changed something: fewer scored units once observations
+  # are missing.
+  expect_true(all(n_partial$n < n_full$n))
+})
+
+
+test_that("diverging per-output-type counts are kept as n_<output_type> columns (#19)", {
+  # When a model submits the same output types on different unit sets, the
+  # scored counts legitimately differ across types. Mock scoring so `mean` and
+  # `quantile` report different counts for modelA; the merged table must keep
+  # both `n_mean` and `n_quantile`, each immediately after the metric block it
+  # refers to, rather than collapsing to a single (wrong) `n`.
+  hub_path <- test_path("testdata", "ecfh")
+  target_id <- "wk inc flu hosp"
+  task_groups_w_target <- get_task_groups_w_target(hub_path, target_id, 0)
+  metric_name_to_output_type <- get_metric_name_to_output_type(
+    task_groups_w_target,
+    c("se_point", "wis")
+  )
+  model_out_tbl <- hubData::connect_hub(hub_path) |>
+    dplyr::collect() |>
+    dplyr::filter(target == target_id)
+  oracle_output <- hubData::connect_target_oracle_output(hub_path) |>
+    dplyr::collect()
+
+  testthat::local_mocked_bindings(
+    score_model_out = function(model_out_tbl, metrics, ...) {
+      if ("wis" %in% metrics) {
+        dplyr::tibble(
+          model_id = c("modelA", "modelB"),
+          wis = c(0.1, 0.2),
+          count = c(12L, 12L)
+        )
+      } else {
+        dplyr::tibble(
+          model_id = c("modelA", "modelB"),
+          se_point = c(2, 3),
+          count = c(10L, 12L)
+        )
+      }
+    }
+  )
+
+  out_path <- withr::local_tempdir()
+  get_and_save_scores(
+    model_out_tbl = model_out_tbl,
+    oracle_output = oracle_output,
+    metric_name_to_output_type = metric_name_to_output_type,
+    relative_metrics = NULL,
+    baseline = NULL,
+    target_id = target_id,
+    eval_set_name = "set",
+    by = NULL,
+    out_path = out_path,
+    transform = NULL,
+    task_groups_w_target = task_groups_w_target
+  )
+  scores <- read.csv(file.path(out_path, target_id, "set", "scores.csv"))
+
+  expect_false("n" %in% names(scores))
+  expect_identical(
+    names(scores),
+    c("model_id", "se_point", "n_mean", "wis", "n_quantile")
+  )
+  modela <- scores[scores$model_id == "modelA", ]
+  expect_equal(modela$n_mean, 10)
+  expect_equal(modela$n_quantile, 12)
+})
+
+
+test_that("agreeing per-output-type counts collapse to a single n (#19)", {
+  # The common case: counts never disagree across output types. modelA submits
+  # both types on the same units (equal counts); modelB submits only quantile
+  # (mean count NA). Neither row carries two differing counts, so the table
+  # collapses to a single `n` column after the metrics.
+  hub_path <- test_path("testdata", "ecfh")
+  target_id <- "wk inc flu hosp"
+  task_groups_w_target <- get_task_groups_w_target(hub_path, target_id, 0)
+  metric_name_to_output_type <- get_metric_name_to_output_type(
+    task_groups_w_target,
+    c("se_point", "wis")
+  )
+  model_out_tbl <- hubData::connect_hub(hub_path) |>
+    dplyr::collect() |>
+    dplyr::filter(target == target_id)
+  oracle_output <- hubData::connect_target_oracle_output(hub_path) |>
+    dplyr::collect()
+
+  testthat::local_mocked_bindings(
+    score_model_out = function(model_out_tbl, metrics, ...) {
+      if ("wis" %in% metrics) {
+        dplyr::tibble(
+          model_id = c("modelA", "modelB"),
+          wis = c(0.1, 0.2),
+          count = c(12L, 12L)
+        )
+      } else {
+        # modelB submits no mean output
+        dplyr::tibble(model_id = "modelA", se_point = 2, count = 12L)
+      }
+    }
+  )
+
+  out_path <- withr::local_tempdir()
+  get_and_save_scores(
+    model_out_tbl = model_out_tbl,
+    oracle_output = oracle_output,
+    metric_name_to_output_type = metric_name_to_output_type,
+    relative_metrics = NULL,
+    baseline = NULL,
+    target_id = target_id,
+    eval_set_name = "set",
+    by = NULL,
+    out_path = out_path,
+    transform = NULL,
+    task_groups_w_target = task_groups_w_target
+  )
+  scores <- read.csv(file.path(out_path, target_id, "set", "scores.csv"))
+
+  expect_false(any(c("n_mean", "n_quantile") %in% names(scores)))
+  expect_identical(names(scores), c("model_id", "se_point", "wis", "n"))
+  expect_equal(scores$n, c(12, 12))
+})

--- a/tests/testthat/test-generate_eval_data.R
+++ b/tests/testthat/test-generate_eval_data.R
@@ -826,10 +826,10 @@ test_that("diverging per-output-type counts are kept as n_<output_type> columns 
 
 
 test_that("agreeing per-output-type counts collapse to a single n (#19)", {
-  # The common case: counts never disagree across output types. modelA submits
-  # both types on the same units (equal counts); modelB submits only quantile
-  # (mean count NA). Neither row carries two differing counts, so the table
-  # collapses to a single `n` column after the metrics.
+  # The common case: no row holds two counts that differ. modelA submits both
+  # types on the same units (equal counts); modelB submits only quantile, so its
+  # mean count is NA. modelB's row keeps the lone quantile count, and that it
+  # submitted no mean output stays visible as an NA `se_point`.
   hub_path <- test_path("testdata", "ecfh")
   target_id <- "wk inc flu hosp"
   task_groups_w_target <- get_task_groups_w_target(hub_path, target_id, 0)
@@ -877,4 +877,6 @@ test_that("agreeing per-output-type counts collapse to a single n (#19)", {
   expect_false(any(c("n_mean", "n_quantile") %in% names(scores)))
   expect_identical(names(scores), c("model_id", "se_point", "wis", "n"))
   expect_equal(scores$n, c(12, 12))
+  # modelB's missing mean output is still legible without an `n_mean` column.
+  expect_equal(scores$se_point, c(2, NA))
 })

--- a/tests/testthat/testdata/create_exp_score_fixtures.R
+++ b/tests/testthat/testdata/create_exp_score_fixtures.R
@@ -11,15 +11,6 @@ oracle_output[["target_end_date"]] <- as.Date(oracle_output[[
 ]])
 
 make_score_fixtures_one_set <- function(set_name, model_out_tbl) {
-  # get number of unique levels for each "non-dependent" task id
-  # (i.e., not target end date)
-  nondependent_task_ids <- c("location", "reference_date", "horizon")
-  n_task_id_levels <- purrr::map_int(
-    nondependent_task_ids,
-    ~ length(unique(model_out_tbl[[.x]]))
-  )
-  names(n_task_id_levels) <- nondependent_task_ids
-
   for (by in list(
     NULL,
     "location",
@@ -64,8 +55,17 @@ make_score_fixtures_one_set <- function(set_name, model_out_tbl) {
       ),
       relative_metrics = c("wis", "ae_median"),
       baseline = "FS-base",
-      by = c("model_id", by)
+      by = c("model_id", by),
+      include_count = TRUE
     )
+    # The scored count is per output type and oracle-aware (forecasts with no
+    # observation are not counted). On the complete ecfh oracle every output
+    # type is scored on the same units, so the counts agree and collapse to a
+    # single `n`; take it from the quantile scores. See #19.
+    scored_counts <- as.data.frame(expected_quantile_scores)[
+      c("model_id", by, "count")
+    ]
+    names(scored_counts)[names(scored_counts) == "count"] <- "n"
     expected_quantile_scores <- as.data.frame(expected_quantile_scores)[
       c(
         "model_id",
@@ -80,26 +80,8 @@ make_score_fixtures_one_set <- function(set_name, model_out_tbl) {
     ]
     expected_scores <- expected_mean_scores |>
       dplyr::left_join(expected_median_scores, by = c("model_id", by)) |>
-      dplyr::left_join(expected_quantile_scores, by = c("model_id", by))
-
-    # add number of scored prediction tasks per model/by group
-    if (is.null(by)) {
-      # group only by model_id
-      # n_tasks is n_locations * n_reference_dates * n_horizons
-      n_tasks <- prod(n_task_id_levels)
-    } else if (by %in% nondependent_task_ids) {
-      # group by location, horizon, or target_end_date
-      # n_tasks is the product of the number of levels for the
-      # "non-by" variables.  For example, if by = horizon, n_tasks = n_locations * n_reference_dates
-      n_tasks <- prod(n_task_id_levels[setdiff(nondependent_task_ids, by)])
-    } else {
-      # group by target_end_date
-      # with our setup for test data, n_tasks is the number of locations
-      # each horizon/reference date combination corresponds to a unique target_end_date
-      n_tasks <- n_task_id_levels["location"]
-    }
-    expected_scores <- expected_scores |>
-      dplyr::mutate(n = n_tasks)
+      dplyr::left_join(expected_quantile_scores, by = c("model_id", by)) |>
+      dplyr::left_join(scored_counts, by = c("model_id", by))
 
     save_path <- testthat::test_path("testdata", "expected-scores")
     if (!dir.exists(save_path)) {


### PR DESCRIPTION
Resolves #19.

## What

`scores.csv`'s `n` (number of predictions scored) previously counted every
prediction a model submitted, including forecasts for units that had no
observation to be scored against. It now counts only the forecasts that were
actually scored (i.e. had a matching oracle observation), so `n` is accurate.

The scored count is intrinsically per output type, so it is computed per output
type and then reconciled:

- When the counts agree across a target's output types (the common case) they
  collapse to a single `n` column, exactly as before.
- When they genuinely diverge (a model scored on different unit sets across
  output types) each is kept as an `n_<output_type>` column, positioned
  immediately after the metric columns it refers to. Front-end presentation of
  that rare case is tracked in hubverse-org/predevals#86.

> [!NOTE]
> Depends on hubEvals's join-aware count (hubverse-org/hubEvals#145), shipped in
> hubEvals 0.4.0; `DESCRIPTION` requires `hubEvals (>= 0.4.0)`.

## Notes

- Builds on #75 (the `full_join` that stopped non-anchor output types being
  dropped), which already landed.
- On the complete-oracle ecfh test data the fixtures regenerate byte-identically;
  the new behaviour is exercised by an integration test that drops observations
  and a pair of tests covering the single-`n` / per-output-type reconciliation.
